### PR TITLE
Improve dev release versioning

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 permissions:
   contents: write
@@ -78,7 +79,7 @@ jobs:
           git tag ${{ env.NEXT_DEV_TAG }}
           git push origin ${{ env.NEXT_DEV_TAG }}
 
-      # Dev builds are not published to distribution channels, only available in Github
+      # Dev builds are not published to distribution channels, only available in Github as draft releases
       - name: Run GoReleaser (Development Build)
         uses: goreleaser/goreleaser-action@v6
         env:
@@ -89,12 +90,15 @@ jobs:
           distribution: goreleaser
           args: release --config .goreleaser-dev.yaml --clean
 
-      # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
+      # Clean up old dev builds except the most recent
       - name: Clean up old development releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Deleting old draft releases (keeping the 2 most recent)..."
+          echo "Wait a bit before deletion to allow active installations to finish..."
+          sleep 10
+
+          echo "Deleting old draft releases (keeping only the most recent)..."
           gh api repos/${{ github.repository }}/releases --paginate |
-            jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[2:] | .[] | .id' |
-            xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the 2 most recent) to delete or failed to delete some."
+            jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[1:] | .[] | .id' |
+            xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the most recent) to delete or failed to delete some."

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -1,12 +1,9 @@
 name: Publish development release
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - main
-      - dev
 
 permissions:
   contents: write

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: write
 
 jobs:
-  build-dev:
+  publish-dev:
     runs-on: ubicloud-standard-8
 
     steps:
@@ -68,9 +68,11 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ env.NEXT_DEV_TAG }}
+          GORELEASER_PREVIOUS_TAG: ${{ env.LATEST_RELEASE_TAG }}
         with:
           distribution: goreleaser
-          args: release --config .goreleaser-dev.yaml --clean --git-tag ${{ env.NEXT_DEV_TAG }}
+          args: release --config .goreleaser-dev.yaml --clean
 
       # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
       - name: Clean up old development releases

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -32,8 +32,10 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Find latest release tag
-        id: latest_tag
+      # Resolve tag for the release:
+      # - If latest release is an official one, bump its patch version by one and suffix with '-dev.1'
+      # - If latest release is a development one, increment the '-dev.N' suffix by one
+      - name: Resolve tag for release
         run: |
           # Find the latest official release tag matching X.Y.Z format
           latest_tag=$(git tag --sort=v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
@@ -67,28 +69,28 @@ jobs:
             echo "NEXT_DEV_TAG=$next_dev_tag" >> $GITHUB_ENV
           fi
 
-      # - name: Tag the version & push
-      #   run: |
-      #     git tag ${{ env.NEXT_DEV_TAG }}
-      #     git push origin ${{ env.NEXT_DEV_TAG }}
+      - name: Tag the version & push
+        run: |
+          git tag ${{ env.NEXT_DEV_TAG }}
+          git push origin ${{ env.NEXT_DEV_TAG }}
 
-      # # Dev builds are not published to distribution channels, only available in Github
-      # - name: Run GoReleaser (Development Build)
-      #   uses: goreleaser/goreleaser-action@v6
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     GORELEASER_CURRENT_TAG: ${{ env.NEXT_DEV_TAG }}
-      #     GORELEASER_PREVIOUS_TAG: ${{ env.LATEST_RELEASE_TAG }}
-      #   with:
-      #     distribution: goreleaser
-      #     args: release --config .goreleaser-dev.yaml --clean
+      # Dev builds are not published to distribution channels, only available in Github
+      - name: Run GoReleaser (Development Build)
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ env.NEXT_DEV_TAG }}
+          GORELEASER_PREVIOUS_TAG: ${{ env.LATEST_RELEASE_TAG }}
+        with:
+          distribution: goreleaser
+          args: release --config .goreleaser-dev.yaml --clean
 
-      # # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
-      # - name: Clean up old development releases
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     echo "Deleting old draft releases (keeping the 2 most recent)..."
-      #     gh api repos/${{ github.repository }}/releases --paginate |
-      #       jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[2:] | .[] | .id' |
-      #       xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the 2 most recent) to delete or failed to delete some."
+      # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
+      - name: Clean up old development releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deleting old draft releases (keeping the 2 most recent)..."
+          gh api repos/${{ github.repository }}/releases --paginate |
+            jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[2:] | .[] | .id' |
+            xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the 2 most recent) to delete or failed to delete some."

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -37,13 +37,20 @@ jobs:
       # - If latest release is a development one, increment the '-dev.N' suffix by one
       - name: Resolve tag for release
         run: |
-          # Find the latest official release tag matching X.Y.Z format
-          latest_tag=$(git tag --sort=v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
+          # Find the latest official release tag matching 'X.Y.Z' format
+          latest_official_tag=$(git tag --sort=v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
+          if [ -z "$latest_official_tag" ]; then
+            echo "Error: Latest official release tag (X.Y.Z) not found!"
+            exit 1
+          fi
+          echo "Latest official release tag: $latest_official_tag"
+          echo "LATEST_RELEASE_TAG=$latest_official_tag" >> $GITHUB_ENV
 
-          # If no tag was found, default to 0.0.0
+          # Find the latest any release tag matching 'X.Y.Z.*' format
+          latest_tag=$(git tag --sort=v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+.*$' | tail -n 1)
           if [ -z "$latest_tag" ]; then
-            echo "Latest official release tag not found, default to 0.0.0"
-            latest_tag="0.0.0"
+            echo "Error: Latest release tag (official or dev) not found!"
+            exit 1
           fi
 
           # Check if $latest_tag has the '-dev.n' suffix.

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: write
 
+# Only allow running one instance at a time to ensure git tags increment correctly
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   publish-dev:
     runs-on: ubicloud-standard-8
@@ -30,56 +35,60 @@ jobs:
       - name: Find latest release tag
         id: latest_tag
         run: |
-          latest_tag=$(git tag --sort=v:refname | tail -n 1)
-          if [ -n "$latest_tag" ]; then
-            echo "Latest release tag found: $latest_tag"
-            echo "LATEST_RELEASE_TAG=$latest_tag" >> $GITHUB_ENV
-          else
-            echo "Latest release tag not found, default to 0.0.0"
-            echo "LATEST_RELEASE_TAG=0.0.0" >> $GITHUB_ENV
+          # Find the latest official release tag matching X.Y.Z format
+          latest_tag=$(git tag --sort=v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
+
+          # If no tag was found, default to 0.0.0
+          if [ -z "$latest_tag" ]; then
+            echo "Latest official release tag not found, default to 0.0.0"
+            latest_tag="0.0.0"
           fi
 
-      - name: Compute next development tag
-        id: next_tag
-        run: |
-          latest_tag="${{ env.LATEST_RELEASE_TAG }}"
+          # Check if $latest_tag has the '-dev.n' suffix.
+          if [[ "$latest_tag" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-dev\.([0-9]+)$ ]]; then
+            # This block will likely not be reached due to the grep filter above
+            echo "Warning: latest_tag ($latest_tag) unexpectedly contains -dev.n suffix."
 
-          # Parse tag using IFS and read
-          IFS='.' read -r major minor patch <<< "$latest_tag"
+            # Bump the '-dev.N' suffix N by 1
+            base_version=${BASH_REMATCH[1]}
+            dev_num=${BASH_REMATCH[2]}
+            next_dev_num=$((dev_num + 1))
+            next_dev_tag="${base_version}-dev.${next_dev_num}"
+            echo "Computed next dev tag (incrementing dev number): $next_dev_tag"
+            echo "NEXT_DEV_TAG=$next_dev_tag" >> $GITHUB_ENV
+          else
+            # Parse tag using IFS and read
+            IFS='.' read -r major minor patch <<< "$latest_tag"
 
-          # Increment patch version
-          next_patch=$((patch + 1))
-          next_version="$major.$minor.$next_patch"
+            # Increment patch version and suffix with '-dev.1'
+            next_patch=$((patch + 1))
+            next_dev_tag="${major}.${minor}.${next_patch}-dev.1"
+            echo "Computed next dev tag: $next_dev_tag"
+            echo "NEXT_DEV_TAG=$next_dev_tag" >> $GITHUB_ENV
+          fi
 
-          # Count commits since last tag
-          commit_count=$(git rev-list --count ${latest_tag}..HEAD)
+      # - name: Tag the version & push
+      #   run: |
+      #     git tag ${{ env.NEXT_DEV_TAG }}
+      #     git push origin ${{ env.NEXT_DEV_TAG }}
 
-          next_dev_tag="${next_version}-dev.${commit_count}"
-          echo "Computed next dev tag: $next_dev_tag"
-          echo "NEXT_DEV_TAG=$next_dev_tag" >> $GITHUB_ENV
+      # # Dev builds are not published to distribution channels, only available in Github
+      # - name: Run GoReleaser (Development Build)
+      #   uses: goreleaser/goreleaser-action@v6
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     GORELEASER_CURRENT_TAG: ${{ env.NEXT_DEV_TAG }}
+      #     GORELEASER_PREVIOUS_TAG: ${{ env.LATEST_RELEASE_TAG }}
+      #   with:
+      #     distribution: goreleaser
+      #     args: release --config .goreleaser-dev.yaml --clean
 
-      - name: Tag the version & push
-        run: |
-          git tag ${{ env.NEXT_DEV_TAG }}
-          git push origin ${{ env.NEXT_DEV_TAG }}
-
-      # Dev builds are not published to distribution channels, only available in Github
-      - name: Run GoReleaser (Development Build)
-        uses: goreleaser/goreleaser-action@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ env.NEXT_DEV_TAG }}
-          GORELEASER_PREVIOUS_TAG: ${{ env.LATEST_RELEASE_TAG }}
-        with:
-          distribution: goreleaser
-          args: release --config .goreleaser-dev.yaml --clean
-
-      # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
-      - name: Clean up old development releases
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Deleting old draft releases (keeping the 2 most recent)..."
-          gh api repos/${{ github.repository }}/releases --paginate |
-            jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[2:] | .[] | .id' |
-            xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the 2 most recent) to delete or failed to delete some."
+      # # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
+      # - name: Clean up old development releases
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     echo "Deleting old draft releases (keeping the 2 most recent)..."
+      #     gh api repos/${{ github.repository }}/releases --paginate |
+      #       jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[2:] | .[] | .id' |
+      #       xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the 2 most recent) to delete or failed to delete some."

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-      - dev
+
+run-name: Publish dev release from ${{ github.head_ref || github.ref_name }}
 
 permissions:
   contents: write

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -1,4 +1,4 @@
-name: Publish development release as v0.0.0
+name: Publish development release
 
 on:
   schedule:
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 permissions:
   contents: write
@@ -26,35 +27,57 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Clean up old development releases
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Find latest release tag
+        id: latest_tag
         run: |
-          # Delete any draft releases
-          gh api repos/${{ github.repository }}/releases --paginate | \
-            jq '.[] | select(.draft == true) | .id' | \
-            xargs -I {} gh api repos/${{ github.repository }}/releases/{} -X DELETE || true
+          latest_tag=$(git tag --sort=v:refname | tail -n 1)
+          if [ -n "$latest_tag" ]; then
+            echo "Latest release tag found: $latest_tag"
+            echo "LATEST_RELEASE_TAG=$latest_tag" >> $GITHUB_ENV
+          else
+            echo "Latest release tag not found, default to 0.0.0"
+            echo "LATEST_RELEASE_TAG=0.0.0" >> $GITHUB_ENV
+          fi
 
-          # Delete any releases named "Development Build" or tagged 0.0.0
-          gh api repos/${{ github.repository }}/releases --paginate | \
-            jq '.[] | select(.name == "Development Build" or .tag_name == "0.0.0") | .id' | \
-            xargs -I {} gh api repos/${{ github.repository }}/releases/{} -X DELETE || true
-
-        # Prevent GoReleaser from picking up any other tag than 0.0.0 for the development build
-      - name: Delete all tags locally
+      - name: Compute next development tag
+        id: next_tag
         run: |
-          git tag -l | xargs -r git tag -d
+          latest_tag="${{ env.LATEST_RELEASE_TAG }}"
 
-      - name: Create a new development build tag
+          # Parse tag using IFS and read
+          IFS='.' read -r major minor patch <<< "$latest_tag"
+
+          # Increment patch version
+          next_patch=$((patch + 1))
+          next_version="$major.$minor.$next_patch"
+
+          # Count commits since last tag
+          commit_count=$(git rev-list --count ${latest_tag}..HEAD)
+
+          next_dev_tag="${next_version}-dev.${commit_count}"
+          echo "Computed next dev tag: $next_dev_tag"
+          echo "NEXT_DEV_TAG=$next_dev_tag" >> $GITHUB_ENV
+
+      - name: Tag the version & push
         run: |
-          git tag 0.0.0
-          git push origin 0.0.0 --force
+          git tag ${{ env.NEXT_DEV_TAG }}
+          git push origin ${{ env.NEXT_DEV_TAG }}
 
-        # Dev builds are not published to distribution channels, only available in Github
+      # Dev builds are not published to distribution channels, only available in Github
       - name: Run GoReleaser (Development Build)
         uses: goreleaser/goreleaser-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           distribution: goreleaser
-          args: release --config .goreleaser-dev.yaml --clean
+          args: release --config .goreleaser-dev.yaml --clean --git-tag ${{ env.NEXT_DEV_TAG }}
+
+      # Clean up old dev builds except the two latest (keep two to avoid deleting versions while someone might be installing them)
+      - name: Clean up old development releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deleting old draft releases (keeping the 2 most recent)..."
+          gh api repos/${{ github.repository }}/releases --paginate |
+            jq '[.[] | select(.draft == true)] | sort_by(.created_at) | reverse | .[2:] | .[] | .id' |
+            xargs -r -I {} sh -c 'gh api repos/${{ github.repository }}/releases/{} -X DELETE && echo "Deleted old draft release {}"' || echo "No old draft releases (beyond the 2 most recent) to delete or failed to delete some."

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  publish:
     runs-on: windows-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ If you have a paid support contract with Metaplay, you can open a ticket on the 
 
 #### Development Build
 
-We do continuously update the latest development build from the `metaplay/cli` repository `main` branch and it can be found on the [releases page](https://github.com/metaplay/cli/releases/tag/0.0.0), but there are no quality guarantees whatsoever associated with it. The development build is primarily intended for our internal use and is made available for Github CI runners to run automated tests on (and with) without the need to always build from scratch.
+We continuously create development builds from the `metaplay/cli` repository `main` branch. These builds are tagged with a `-dev.N` suffix (e.g., `1.2.4-dev.1`) and published as draft releases. You can find the latest development build on the main [releases page](https://github.com/metaplay/cli/releases). The development builds are primarily intended for testing purposes and should generally not be used.
 
 Development builds do not currently perform any version checks (for the purpose of new release notifications), and the `update cli` command is disabled on development builds as well. If you need to override this behavior, you can mock up a specific version number with the following:
 

--- a/install.sh
+++ b/install.sh
@@ -119,9 +119,20 @@ print_verbose "Install dir: $INSTALL_DIR"
 
 # If no VERSION specified, discover latest via GitHub API
 if [ -z "$VERSION" ]; then
-  print_verbose "No version specified. Finding latest release..."
+  print_verbose "No version specified. Finding latest official release..."
   VERSION=$(curl -sSfL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-  print_verbose "Latest version is: $VERSION"
+  print_verbose "Latest official version is: $VERSION"
+elif [ "$VERSION" = "latest-dev" ]; then
+  print_verbose "Version specified as 'latest-dev'. Finding latest development release..."
+  # Fetch all releases (newest first), get the tag_name of the very first one
+  VERSION=$(curl -sSfL "https://api.github.com/repos/${REPO}/releases" | grep '"tag_name":' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/')
+  print_verbose "Latest development version is: $VERSION"
+fi
+
+# Validate that a version was determined
+if [ -z "$VERSION" ]; then
+  print_error "Could not determine a version to install."
+  exit 1
 fi
 
 # Construct the download URL


### PR DESCRIPTION
Publish the dev versions as 'X.Y.Z-dev.N' (instead of '0.0.0') where 'Z' is the patch version of latest official release plus 1, and 'N' is incremented by one for each subsequent build.

Allow passing `--version latest-dev' to `install.sh` to install the latest version (dev or official).

This has the following benefits:
- There is always a latest (dev) version to install.
- The dev builds are now uniquely numbered, allowing better diagnostics in case of failures.
- The changelog for the dev build is now the list of changes from the previous official build.