### PR TITLE
Verify that both ipv4 and ipv6 are available in port selection logic

### DIFF
--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -54,9 +54,13 @@ func generateCodeVerifierAndChallenge() (verifier, challenge string) {
 // Note: We try these in reverse order as 5000 is more likely to be used by other systems.
 func findAvailableCallbackPort() (net.Listener, int, error) {
 	for tryPort := 5004; tryPort >= 5000; tryPort-- {
-		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", tryPort))
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", tryPort))
 		if err == nil {
-			return listener, tryPort, nil
+			ipv6Listener, err := net.Listen("tcp", fmt.Sprintf("[::1]:%d", tryPort))
+			if err == nil {
+				ipv6Listener.Close()
+				return listener, tryPort, nil
+			}
 		}
 	}
 	return nil, 0, fmt.Errorf("no available ports between 5000-5004")

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -54,6 +54,7 @@ func generateCodeVerifierAndChallenge() (verifier, challenge string) {
 // Note: We try these in reverse order as 5000 is more likely to be used by other systems.
 func findAvailableCallbackPort() (net.Listener, int, error) {
 	for tryPort := 5004; tryPort >= 5000; tryPort-- {
+		// Verify that both ipv4 and ipv6 are available, using `:port` as addr seems to only check ipv6.
 		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", tryPort))
 		if err == nil {
 			ipv6Listener, err := net.Listen("tcp", fmt.Sprintf("[::1]:%d", tryPort))


### PR DESCRIPTION
Slightly funky but currently the `net.Listen` call seems to only check whether the ipv6 host is available (when using `:port` as addr) rather than both ipv4 and ipv6. This break with the tilt setup as supabase storage api is listening on port 5000 on ipv4. 

We then listen on the ipv4 addr, instead of the ipv6 addr, as for some reason my browser won't resolve to the ipv6 addr.