### PR TITLE
Fix update aws credentials to include version

### DIFF
--- a/pkg/envapi/target_environment.go
+++ b/pkg/envapi/target_environment.go
@@ -350,7 +350,7 @@ func (target *TargetEnvironment) GetAWSCredentials() (*AWSCredentials, error) {
 		return nil, fmt.Errorf("AWS credential missing SecretAccessKey")
 	}
 
-	awsCredentials.Version = 1;
+	awsCredentials.Version = 1
 	
 	return &awsCredentials, err
 }

--- a/pkg/envapi/target_environment.go
+++ b/pkg/envapi/target_environment.go
@@ -43,6 +43,7 @@ type TargetEnvironment struct {
 // Container for AWS access credentials into the target environment.
 // The JSON names match those used by AWS.
 type AWSCredentials struct {
+	Version         int    `json:"Version"`
 	AccessKeyID     string `json:"AccessKeyId"`
 	SecretAccessKey string `json:"SecretAccessKey"`
 	SessionToken    string `json:"SessionToken"`
@@ -348,6 +349,9 @@ func (target *TargetEnvironment) GetAWSCredentials() (*AWSCredentials, error) {
 	if awsCredentials.SecretAccessKey == "" {
 		return nil, fmt.Errorf("AWS credential missing SecretAccessKey")
 	}
+
+	awsCredentials.Version = 1;
+	
 	return &awsCredentials, err
 }
 


### PR DESCRIPTION
Running the following command from the sample
```
aws sts get-caller-identity --profile <>
```
fails because of the following update to the aws cli.  
https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html#feature-process-credentials-output

Adding the default version = 1 field in the json fixes it. 