### PR TITLE
feat: New command 'debug database'

### DIFF
--- a/cmd/debug_collect_cpu_profile.go
+++ b/cmd/debug_collect_cpu_profile.go
@@ -274,7 +274,7 @@ func (o *debugCollectCPUProfileOpts) collectAndRetrieveCPUProfile(ctx context.Co
 
 	// Copy the CPU profile file from the debug container
 	log.Info().Msgf("Retrieving CPU profile to local file %s...", o.flagOutputPath)
-	err = copyFileFromPod(ctx, kubeCli, podName, debugContainerName, "/tmp", remoteFileName, o.flagOutputPath)
+	err = copyFileFromDebugPod(ctx, kubeCli, podName, debugContainerName, "/tmp", remoteFileName, o.flagOutputPath)
 	if err != nil {
 		log.Error().Msgf("Failed to copy CPU profile: %v", err)
 		return err

--- a/cmd/debug_collect_heap_dump.go
+++ b/cmd/debug_collect_heap_dump.go
@@ -227,7 +227,7 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 
 	// Copy the heap dump file from the debug container using tar pipe (using Kubernetes API)
 	log.Info().Msgf("Retrieving heap dump to local file %s...", o.flagOutputPath)
-	err = copyFileFromPod(ctx, kubeCli, podName, debugContainerName, "/tmp", filepath.Base(o.flagOutputPath), o.flagOutputPath)
+	err = copyFileFromDebugPod(ctx, kubeCli, podName, debugContainerName, "/tmp", filepath.Base(o.flagOutputPath), o.flagOutputPath)
 	if err != nil {
 		log.Error().Msgf("Failed to copy heap dump: %v", err)
 		return err

--- a/pkg/envapi/new_gameserver_cr.go
+++ b/pkg/envapi/new_gameserver_cr.go
@@ -118,8 +118,8 @@ func getGameServerNewCR(ctx context.Context, kubeCli *KubeClient) (*NewGameServe
 	// Output parsed NewGameServerCR struct
 	log.Debug().Msgf("NewGameServerCR Name: %s", gameServerCR.Name)
 	log.Debug().Msgf("Namespace: %s", gameServerCR.Namespace)
-	log.Debug().Msgf("Spec: %+v", gameServerCR.Spec)
-	log.Debug().Msgf("Status: %+v", gameServerCR.Status)
+	log.Debug().Msgf("Game server CR spec: %+v", gameServerCR.Spec)
+	log.Debug().Msgf("Game server CR status: %+v", gameServerCR.Status)
 
 	return &gameServerCR, nil
 }


### PR DESCRIPTION
Add a new command 'debug database <env> <shardNdx>' to start an interactive SQL client against the target database replica.

By default, the read-only replica is used (assuming one exists for the environment). Use `--read-write` to connect to the primary read-write replica.