### PR TITLE
Add --query to 'debug database' to run queries directly from command line

### DIFF
--- a/cmd/debug_database.go
+++ b/cmd/debug_database.go
@@ -97,8 +97,8 @@ func init() {
 			# Connect to the read-write replica instead of the default read-only replica
 			metaplay debug database tough-falcons --read-write
 
-			# Run a query on the first shard and print the result
-			metaplay debug database tough-falcons --query "SELECT COUNT(*) FROM players;"
+			# Run a query on the first shard and exit immediately after
+			metaplay debug database tough-falcons 0 --query "SELECT COUNT(*) FROM players"
 		`),
 		Run: runCommand(&o),
 	}

--- a/cmd/debug_database.go
+++ b/cmd/debug_database.go
@@ -98,12 +98,12 @@ func init() {
 			metaplay debug database tough-falcons --read-write
 
 			# Run a query on the first shard and exit immediately after
-			metaplay debug database tough-falcons 0 --query "SELECT COUNT(*) FROM players"
+			metaplay debug database tough-falcons 0 --query "SELECT COUNT(*) FROM Players"
 		`),
 		Run: runCommand(&o),
 	}
 	cmd.Flags().BoolVar(&o.flagReadWrite, "read-write", false, "Connect to the read-write replica (default: read-only)")
-	cmd.Flags().StringVar(&o.flagQuery, "query", "", "Run this SQL query and exit (non-interactive)")
+	cmd.Flags().StringVarP(&o.flagQuery, "query", "q", "", "Run this SQL query and exit (non-interactive)")
 	debugCmd.AddCommand(cmd)
 }
 


### PR DESCRIPTION
Allow running queries in non-interactive mode directly using the CLI.

Future todo: Make this useful in scripted mode by not printing the boilerplate.