### PR TITLE
Fix err propagation in "get kubeconfig"

### DIFF
--- a/cmd/get_kubeconfig.go
+++ b/cmd/get_kubeconfig.go
@@ -119,7 +119,8 @@ func (o *getKubeConfigOpts) Run(cmd *cobra.Command) error {
 	switch credentialsType {
 	case "dynamic":
 		// Fetch the userinfo for an email.
-		userinfo, err := auth.FetchUserInfo(authProvider, tokenSet)
+		var userinfo *auth.UserInfoResponse
+		userinfo, err = auth.FetchUserInfo(authProvider, tokenSet)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`userinfo, err :=` creates a new scope, which then silently eats errors from `kubeconfigPayload, err = targetEnv.GetKubeConfigWithExecCredential(userinfo.Email)`

This PR avoids creating a new `err` variable.