### PR TITLE
Fix Docker metadata extraction on macOS

### DIFF
--- a/cmd/build_image.go
+++ b/cmd/build_image.go
@@ -405,7 +405,7 @@ func checkDockerAvailable() error {
 		done <- checkCommand("docker", "info")
 	}()
 
-	// Wait for docker to reponds .. print a waiting message after 1sec
+	// Wait for docker to respond .. print a waiting message after 1sec
 	select {
 	case err := <-done:
 		if err != nil {


### PR DESCRIPTION
Use official docker library instead of go-containerregistry when resolving metadata about local docker images. The go-containerregistry does not seem to work on macOS in all scenarios.

We still use go-containerregistry when resolving information about remote docker images.