### PR TITLE
Clarify redirect status code is expected in LiveOps Dashboard check

### DIFF
--- a/pkg/envapi/wait_server_ready.go
+++ b/pkg/envapi/wait_server_ready.go
@@ -613,9 +613,14 @@ func waitForHTTPServerToRespond(ctx context.Context, output *tui.TaskOutput, url
 				output.AppendLinef("Error connecting to %s: %v. Retrying...", url, err)
 			} else {
 				defer resp.Body.Close()
-				// Accept 2xx (Success) and 3xx (Redirection) status codes.
-				if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+				switch {
+				case resp.StatusCode >= 200 && resp.StatusCode < 300:
+					// Accept 2xx (Success) status codes.
 					output.AppendLinef("Successfully connected to %s. Status: %s", url, resp.Status)
+					return nil
+				case resp.StatusCode >= 300 && resp.StatusCode < 400:
+					// Accept 3xx (Redirection) status codes.
+					output.AppendLinef("Successfully received login redirect from %s. Status: %s", url, resp.Status)
 					return nil
 				}
 				output.AppendLinef("Received status code %d from %s. Retrying...", resp.StatusCode, url)


### PR DESCRIPTION
The log message is suspicious (especially since it's the last in the checklist, so that's where you are looking first when things go wrong):
```
Wait for LiveOps Dashboard to serve traffic...
  Waiting for HTTP server https://example-admin.env.stack.tld to respond (timeout: 5m0s)
  Successfully connected to https://example-admin.env.stack.tld. Status: 302 Moved Temporarily
```

Clarify the message:
```
Wait for LiveOps Dashboard to serve traffic...
  Waiting for HTTP server https://example-admin.env.stack.tld to respond (timeout: 5m0s)
  Successfully received login redirect from https://example-admin.env.stack.tld. Status: 302 Moved Temporarily
```