### PR TITLE
Ensure image tag or repo is not overriden in deploy values.

### DIFF
--- a/cmd/deploy_botclient.go
+++ b/cmd/deploy_botclient.go
@@ -189,7 +189,7 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 
 	// Default Helm values. The user Helm values files are applied on top so
 	// all these values can be overridden by the user.
-	helmValues := map[string]any{
+	helmDefaultValues := map[string]any{
 		"environmentFamily": "Development", // not really but shouldn't matter in botclient
 		"botclients": map[string]any{
 			"targetPort":         9339,
@@ -218,6 +218,14 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 			"requests": map[string]any{
 				"memory": "128Mi",
 				"cpu":    0.1,
+			},
+		},
+	}
+	helmRequiredValues := map[string]any{
+		"botclients": map[string]any{
+			"image": map[string]any{
+				"repository": envDetails.Deployment.EcrRepo,
+				"tag":        o.argImageTag,
 			},
 		},
 	}
@@ -274,7 +282,8 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 			helmChartPath,
 			useHelmChartVersion,
 			valuesFiles,
-			helmValues,
+			helmDefaultValues,
+			helmRequiredValues,
 			5*time.Minute)
 		return err
 	})

--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -345,7 +345,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 	// Default Helm values. The user Helm values files are applied on top so
 	// all these values can be overridden by the user.
 	// \todo check for the existence of the runtime options files
-	helmValues := map[string]any{
+	helmDefaultValues := map[string]any{
 		"environment":       envConfig.Name,
 		"environmentFamily": envConfig.GetEnvironmentFamily(),
 		"config": map[string]any{
@@ -360,10 +360,13 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 		"sdk": map[string]any{
 			"version": imageInfo.SdkVersion,
 		},
-		"image": map[string]any{
-			"tag": imageTag,
-		},
 		"shards": shardConfig,
+	}
+	helmRequiredValues := map[string]any{
+		"image": map[string]any{
+			"tag":        imageTag,
+			"repository": envDetails.Deployment.EcrRepo,
+		},
 	}
 
 	// Resolve Helm release name. If not specified, default to:
@@ -459,7 +462,8 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 			helmChartPath,
 			useHelmChartVersion,
 			valuesFiles,
-			helmValues,
+			helmDefaultValues,
+			helmRequiredValues,
 			5*time.Minute)
 		return err
 	})


### PR DESCRIPTION
In case helm values contains `image.tag` or `image.repository`, these take precedence over the values given to metaplaycli on command line.

This PR adds a check that helm value files cannot change these two fields. If helm values and the tag disagree, deploy fails.

The most likely way to set `tag` "wrong" in values file is to have `tag: latest`. This might have worked with manual deploy scripts, but metaplaycli does not tag images with `latest`, causing deployments to fail starting due to image pulling errors.