### PR TITLE
Print `debug database` messages stderr to allow forwarding

### DIFF
--- a/cmd/debug_database.go
+++ b/cmd/debug_database.go
@@ -164,13 +164,13 @@ func (o *debugDatabaseOpts) Run(cmd *cobra.Command) error {
 	pod := &shardSetsWithPods[0].Pods[0]
 
 	// Fetch the infrastructure options YAML using the debug container
-	log.Debug().Msgf("Fetch infra options YAML from pod: %s", pod.Name)
+	stderrLogger.Debug().Msgf("Fetch infra options YAML from pod: %s", pod.Name)
 	yamlContent, err := o.fetchInfraOptionsYaml(cmd.Context(), kubeCli, pod.Name, metaplayServerContainerName)
 	if err != nil {
 		return err
 	}
 
-	log.Debug().Msgf("Infrastructure options YAML:\n%s", yamlContent)
+	stderrLogger.Debug().Msgf("Infrastructure options YAML:\n%s", yamlContent)
 
 	// Parse the infrastructure options (only database section)
 	var infra metaplayInfraOptions
@@ -230,10 +230,10 @@ func (o *debugDatabaseOpts) Run(cmd *cobra.Command) error {
 	if o.flagReadWrite {
 		replicaType = "read-write"
 	}
-	log.Info().Msg("")
-	log.Info().Msgf("Use database shard:   %s (%d available)", styles.RenderTechnical(fmt.Sprintf("%d", shardIndex)), len(shards))
-	log.Info().Msgf("Use database replica: %s", styles.RenderTechnical(replicaType))
-	log.Info().Msg("")
+	stderrLogger.Info().Msg("")
+	stderrLogger.Info().Msgf("Use database shard:   %s (%d available)", styles.RenderTechnical(fmt.Sprintf("%d", shardIndex)), len(shards))
+	stderrLogger.Info().Msgf("Use database replica: %s", styles.RenderTechnical(replicaType))
+	stderrLogger.Info().Msg("")
 
 	// Connect to the database shard
 	return o.connectToDatabaseShard(cmd.Context(), kubeCli, pod.Name, debugContainerName, targetShard)
@@ -244,12 +244,12 @@ func (o *debugDatabaseOpts) fetchInfraOptionsYaml(ctx context.Context, kubeCli *
 	// Use readFileFromPod with followSymlinks=true to handle symlinked files
 	contents, err := readFileFromPod(ctx, kubeCli, podName, containerName, "/etc/metaplay", "runtimeoptions.yaml")
 	if err != nil {
-		log.Error().Msgf("Failed to read infrastructure options: %v", err)
+		stderrLogger.Error().Msgf("Failed to read infrastructure options: %v", err)
 		return "", fmt.Errorf("failed to read infrastructure options: %w", err)
 	}
 
 	if len(contents) == 0 {
-		log.Warn().Msg("Infrastructure options file is empty")
+		stderrLogger.Warn().Msg("Infrastructure options file is empty")
 	}
 
 	return string(contents), nil
@@ -275,7 +275,7 @@ func (o *debugDatabaseOpts) connectToDatabaseShard(ctx context.Context, kubeCli 
 		shard.DatabaseName)
 
 	if o.flagQuery != "" {
-		log.Info().Msgf("Run query: %s", o.flagQuery)
+		stderrLogger.Info().Msgf("Run query: %s", o.flagQuery)
 		mysqlCmd += fmt.Sprintf(" -e %q", o.flagQuery)
 	}
 
@@ -305,7 +305,7 @@ func (o *debugDatabaseOpts) connectToDatabaseShard(ctx context.Context, kubeCli 
 	if isInteractive {
 		// Put terminal in raw mode if needed
 		if fd := int(os.Stdin.Fd()); term.IsTerminal(fd) {
-			log.Debug().Msgf("Put terminal in raw mode")
+			stderrLogger.Debug().Msgf("Put terminal in raw mode")
 			state, err := term.MakeRaw(fd)
 			if err != nil {
 				return fmt.Errorf("failed to set terminal to raw mode: %v", err)
@@ -343,9 +343,9 @@ func (o *debugDatabaseOpts) connectToDatabaseShard(ctx context.Context, kubeCli 
 	}
 
 	// Start the stream to the mysql client
-	log.Debug().Msgf("Starting SPDY stream to mysql client")
+	stderrLogger.Debug().Msgf("Starting SPDY stream to mysql client")
 	err = exec.StreamWithContext(ctx, streamOptions)
-	log.Debug().Msgf("Stream terminated with result: %v", err)
+	stderrLogger.Debug().Msgf("Stream terminated with result: %v", err)
 	return err
 }
 

--- a/cmd/debug_database.go
+++ b/cmd/debug_database.go
@@ -125,6 +125,10 @@ func (o *debugDatabaseOpts) Prepare(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("in non-interactive mode, argument SHARD must be specified")
 		}
 	}
+	// Non-interactive mode requires the query in the command line
+	if o.flagQuery == "" && !tui.IsInteractiveMode() {
+		return fmt.Errorf("in non-interactive mode, argument QUERY must be specified")
+	}
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ var rootCmd = &cobra.Command{
 			useColors = false
 		} else {
 			if colorMode != "auto" {
-				fmt.Printf("ERROR: Invalid color mode (--color or METAPLAYCLI_COLOR): %s. Allowed values are yes/no/auto.\n", flagColorMode)
+				fmt.Fprintf(os.Stderr, "ERROR: Invalid color mode (--color or METAPLAYCLI_COLOR): %s. Allowed values are yes/no/auto.\n", flagColorMode)
 				os.Exit(2)
 			}
 			useColors = hasTerminal
@@ -336,9 +336,9 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		if hasPosArgs {
 			err := posArgs.Arguments().ParseCommandLine(args)
 			if err != nil {
-				log.Error().Msgf("Expected usage: %s", cmd.UseLine())
-				log.Warn().Msgf("%s", posArgs.args.GetHelpText())
-				log.Info().Msgf("Run with --help flag for full help.")
+				stderrLogger.Error().Msgf("Expected usage: %s", cmd.UseLine())
+				stderrLogger.Warn().Msgf("%s", posArgs.args.GetHelpText())
+				stderrLogger.Info().Msgf("Run with --help flag for full help.")
 				os.Exit(2)
 			}
 		} else {
@@ -348,15 +348,15 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		// Prepare the command.
 		err := opts.Prepare(cmd, args)
 		if err != nil {
-			log.Info().Msgf("%s", cmd.UsageString())
-			log.Error().Msgf("USAGE ERROR: %v", err)
+			stderrLogger.Info().Msgf("%s", cmd.UsageString())
+			stderrLogger.Error().Msgf("USAGE ERROR: %v", err)
 			os.Exit(2)
 		}
 
 		// Run the command.
 		err = opts.Run(cmd)
 		if err != nil {
-			log.Error().Msgf("ERROR: %v", err)
+			stderrLogger.Error().Msgf("ERROR: %v", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
This PR:
* Prints all USAGE errors to stderr. This is useful when forwarding output to file and mess up command line syntax (or syntax is different, like shard index in `debug database`). You don't want chatter in your output.
* Prints log messages in `debug database` to stderr. This is useful when forwarding output to file. You don't want chatter in your output.
* If output is redirected, requires `--query`. It's confusing to have "interactive" session where stdout is redirected but stdin is not.
   * This means `debug database` can no longer be used in a pipeline such as `gen-sql-query-stream | debug database .. > output`
   * But this is not a regression. In this case `mysql` was in non-batch mode and printed ansi escape and help texts, making output unusable for machine-use.
   * We can get back to this when a real use case emerges.

---
The this is preparatory work for dumping tool e.g. `metaplay debug database tough-falcons 0 --dump Table1 --dump Table2 --output script.sql --dump-add-drop-table` which is pretty much the same logic but we'd invoke `mysqldump` instead of `mysql`. 
( --output is needed to bypass low perf on windows shell forwarding)
 