### PR TITLE
Enable chart schema values validation for recent versions of Helm charts.

### DIFF
--- a/cmd/deploy_botclient.go
+++ b/cmd/deploy_botclient.go
@@ -284,7 +284,8 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 			valuesFiles,
 			helmDefaultValues,
 			helmRequiredValues,
-			5*time.Minute)
+			5*time.Minute,
+			true)
 		return err
 	})
 

--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -346,6 +346,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 	// This happens because Helm, or https://github.com/santhosh-tekuri/jsonschema where the inputs are validated,
 	// doesn't allow []map[string]any. Its typeOf() function only accepts `[]any` as array types, not other types
 	// of arrays, like []map[string]any.
+	// Bug report in Helm: https://github.com/helm/helm/issues/31148 -- if the issue gets fixed, this code can be removed.
 	untypedShardsConfig := make([]any, len(shardsConfig))
 	for i, v := range shardsConfig {
 		untypedShardsConfig[i] = v

--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -317,9 +317,9 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 
 	// Default shard config based on environment type.
 	// \todo Auto-detect these from the infrastructure.
-	var shardConfig []map[string]any
+	var shardsConfig []map[string]any
 	if envConfig.Type == portalapi.EnvironmentTypeProduction || envConfig.Type == portalapi.EnvironmentTypeStaging {
-		shardConfig = []map[string]any{
+		shardsConfig = []map[string]any{
 			{
 				"name":      "all",
 				"singleton": true,
@@ -330,7 +330,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 			},
 		}
 	} else {
-		shardConfig = []map[string]any{
+		shardsConfig = []map[string]any{
 			{
 				"name":      "all",
 				"singleton": true,
@@ -340,6 +340,15 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 				},
 			},
 		}
+	}
+
+	// Convert shardConfig to []any to avoid JSON schema validation type errors.
+	// This happens because Helm, or https://github.com/santhosh-tekuri/jsonschema where the inputs are validated,
+	// doesn't allow []map[string]any. Its typeOf() function only accepts `[]any` as array types, not other types
+	// of arrays, like []map[string]any.
+	untypedShardsConfig := make([]any, len(shardsConfig))
+	for i, v := range shardsConfig {
+		untypedShardsConfig[i] = v
 	}
 
 	// Default Helm values. The user Helm values files are applied on top so
@@ -360,7 +369,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 		"sdk": map[string]any{
 			"version": imageInfo.SdkVersion,
 		},
-		"shards": shardConfig,
+		"shards": untypedShardsConfig,
 	}
 	helmRequiredValues := map[string]any{
 		"image": map[string]any{
@@ -451,6 +460,50 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 		})
 	}
 
+	// Figure out whether the values file JSON schema can be validated:
+	// - v0.9+ (including v1.x+, v0.10.x+, and prereleases) can be validated.
+	// - v0.8.1+ (including prereleases) can be validated, but v0.8.0 cannot.
+	// - v0.7.x and earlier cannot be validated.
+	// - Local charts are validated (we assume recent versions are used).
+	validateJsonSchema := false
+	if useHelmChartVersion != "local" {
+		chartVersion, err := semver.NewVersion(useHelmChartVersion)
+		if err != nil {
+			log.Warn().Err(err).Msgf("Failed to parse Helm chart version '%s', skipping schema validation", useHelmChartVersion)
+			validateJsonSchema = false
+		} else {
+			major := chartVersion.Major()
+			minor := chartVersion.Minor()
+			patch := chartVersion.Patch()
+
+			if major >= 1 || (major == 0 && minor >= 9) {
+				// v0.9 and later can be validated (including v0.10.x, v1.x.x and later, and v0.9.x-pre versions)
+				validateJsonSchema = true
+			} else if major == 0 && minor == 8 {
+				// For v0.8 series: don't validate for v0.8.0, but do validate for >=v0.8.1 (including pre releases)
+				if patch == 0 {
+					// Exactly v0.8.0 cannot be validated
+					validateJsonSchema = false
+				} else {
+					// v0.8.1+ (including prereleases) can be validated
+					validateJsonSchema = true
+				}
+			} else {
+				// v0.7 and earlier cannot be validated
+				log.Warn().Msgf("Helm chart version '%s' is below minimum supported version, skipping schema validation", useHelmChartVersion)
+				validateJsonSchema = false
+			}
+
+			log.Debug().Msgf("Helm chart version '%s': schema validation %s", useHelmChartVersion,
+				map[bool]string{true: "enabled", false: "disabled"}[validateJsonSchema])
+		}
+	} else {
+		// For local charts, we assume recent versions, and enable validation.
+		// \todo Add flag for disabling this, if needed.
+		log.Debug().Msg("Using local Helm chart, enable schema validation")
+		validateJsonSchema = true
+	}
+
 	// Install or upgrade the Helm chart.
 	taskRunner.AddTask("Deploy game server using Helm", func(output *tui.TaskOutput) error {
 		_, err := helmutil.HelmUpgradeOrInstall(
@@ -464,7 +517,8 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 			valuesFiles,
 			helmDefaultValues,
 			helmRequiredValues,
-			5*time.Minute)
+			5*time.Minute,
+			validateJsonSchema)
 		return err
 	})
 

--- a/pkg/helmutil/upgrade_or_install.go
+++ b/pkg/helmutil/upgrade_or_install.go
@@ -38,6 +38,7 @@ func HelmUpgradeOrInstall(
 	defaultValues map[string]any,
 	requiredValues map[string]any,
 	timeout time.Duration,
+	validateValuesSchema bool,
 ) (*release.Release, error) {
 	// Show header at top
 	headerLine := fmt.Sprintf("Deploying chart %s as release %s", chartURL, releaseName)
@@ -58,7 +59,6 @@ func HelmUpgradeOrInstall(
 	// Determine if install or upgrade based on existence of release:
 	// - Use install if no previous Helm release exists
 	// - Use upgrade if a previous Helm release exists
-	// \todo Enable schema validation (don't set SkipSchemaValidation) once we have updated the chart to use a recent version of Helm.
 	if existingRelease == nil {
 		output.AppendLine("No existing release found, install new release")
 		installCmd = action.NewInstall(actionConfig)
@@ -67,8 +67,8 @@ func HelmUpgradeOrInstall(
 		installCmd.Namespace = namespace
 		installCmd.Wait = true
 		installCmd.Timeout = timeout
-		installCmd.Devel = true                // If version is development, accept it
-		installCmd.SkipSchemaValidation = true // Disable schema validation for legacy charts
+		installCmd.Devel = true                                 // If version is development, accept it
+		installCmd.SkipSchemaValidation = !validateValuesSchema // Disable schema validation for legacy charts
 		chartPathOptions = &installCmd.ChartPathOptions
 	} else {
 		output.AppendLinef("Existing release found (version %s), upgrade existing release", existingRelease.Chart.Metadata.Version)
@@ -77,11 +77,11 @@ func HelmUpgradeOrInstall(
 		upgradeCmd.Namespace = namespace
 		upgradeCmd.Wait = true
 		upgradeCmd.Timeout = timeout
-		upgradeCmd.MaxHistory = 10             // Keep 10 releases max
-		upgradeCmd.Devel = true                // If version is development, accept it
-		upgradeCmd.Atomic = false              // Don't rollback on failures to not hide errors
-		upgradeCmd.CleanupOnFail = true        // Clean resources on failure
-		upgradeCmd.SkipSchemaValidation = true // Disable schema validation for legacy charts
+		upgradeCmd.MaxHistory = 10                              // Keep 10 releases max
+		upgradeCmd.Devel = true                                 // If version is development, accept it
+		upgradeCmd.Atomic = false                               // Don't rollback on failures to not hide errors
+		upgradeCmd.CleanupOnFail = true                         // Clean resources on failure
+		upgradeCmd.SkipSchemaValidation = !validateValuesSchema // Disable schema validation for legacy charts
 		chartPathOptions = &upgradeCmd.ChartPathOptions
 	}
 
@@ -138,7 +138,7 @@ func HelmUpgradeOrInstall(
 	if err != nil {
 		log.Warn().Msgf("Failed to marshal values as YAML: %+v", finalValueMap)
 	} else {
-		log.Debug().Msgf("Default Helm values:\n%s", finalValuesYAML)
+		log.Debug().Msgf("Final Helm values:\n%s", finalValuesYAML)
 	}
 
 	// Run install or upgrade install


### PR DESCRIPTION
Re-enable the Helm chart values schema validation for chart versions that have the schema configuration fixed:
- For any v0.9.x and newer (including v0.9.x and v1.x.x), enable the validation.
- For v0.8.x, disable validation for v0.8.0, but enable for v0.8.1 and newer. (There's no plan to release v0.8.1, but just in case we do.)
- For v0.7.x and older, keep the validation disabled -- these are not supported by the new CLI anyway.

Note: The botclient (`metaplay-loadtest`) chart was not affected by failures, so it's always validated.

Cast the `shardsConfig` value to `[]any` (an untyped array) because Helm v3.18.5 does not handle typed arrays-of-objects (`[]map[string]any`) properly.