### PR TITLE
Retry copying of files from pod a few times.

### DIFF
--- a/cmd/debug_collect_cpu_profile.go
+++ b/cmd/debug_collect_cpu_profile.go
@@ -274,7 +274,7 @@ func (o *debugCollectCPUProfileOpts) collectAndRetrieveCPUProfile(ctx context.Co
 
 	// Copy the CPU profile file from the debug container
 	log.Info().Msgf("Retrieving CPU profile to local file %s...", o.flagOutputPath)
-	err = copyFileFromDebugPod(ctx, kubeCli, podName, debugContainerName, "/tmp", remoteFileName, o.flagOutputPath)
+	err = copyFileFromDebugPod(ctx, kubeCli, podName, debugContainerName, "/tmp", remoteFileName, o.flagOutputPath, 3)
 	if err != nil {
 		log.Error().Msgf("Failed to copy CPU profile: %v", err)
 		return err

--- a/cmd/debug_collect_heap_dump.go
+++ b/cmd/debug_collect_heap_dump.go
@@ -227,7 +227,7 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 
 	// Copy the heap dump file from the debug container using tar pipe (using Kubernetes API)
 	log.Info().Msgf("Retrieving heap dump to local file %s...", o.flagOutputPath)
-	err = copyFileFromDebugPod(ctx, kubeCli, podName, debugContainerName, "/tmp", filepath.Base(o.flagOutputPath), o.flagOutputPath)
+	err = copyFileFromDebugPod(ctx, kubeCli, podName, debugContainerName, "/tmp", filepath.Base(o.flagOutputPath), o.flagOutputPath, 3)
 	if err != nil {
 		log.Error().Msgf("Failed to copy heap dump: %v", err)
 		return err


### PR DESCRIPTION
This makes the CPU profiling and heap dump collecting more resilient to networking errors.