### PR TITLE
Use GitHub Pages for version discovery to avoid rate limits

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Configure GitHub CLI
+        run: gh auth status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Copy the install.sh to be available publicly at https://metaplay.github.io/cli/install.sh.
       # GitHub Pages isn't throttled like the https://raw.githubusercontent.com/metaplay/cli/main/install.sh.
       - name: Prepare Pages output
@@ -36,6 +41,10 @@ jobs:
           mkdir site
           cp install.sh site/
           cp install.ps1 site/
+
+          # Write latest release version to site/latest-version.txt
+          # This allows installers to discover the latest version without hitting GitHub's rate-limited API.
+          gh release view --json tagName -q .tagName > site/latest-version.txt
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -10,10 +10,10 @@ on:
       - install.sh
       - install.ps1
       - .github/workflows/publish-pages.yml
-    # Trigger on version tags for official releases like '1.2.3' (but not for dev releases like '1.2.3-xyz').
-    # Keeps the command reference up-to-date with latest official release.
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  # Trigger on release publication to update latest-version.txt.
+  # Using 'published' event ensures the release exists before we query it (avoids race condition with GoReleaser).
+  release:
+    types: [published]
 
 permissions:
   contents: read     # to checkout your code

--- a/install.ps1
+++ b/install.ps1
@@ -100,56 +100,68 @@ function Invoke-WithRetry {
     }
 }
 
-# If no version specified, discover latest via GitHub redirect
+# If no version specified, discover latest via GitHub Pages (avoids rate limits)
 if (-not $Version) {
     Print-Verbose 'No version specified. Finding latest official release...'
-    $latestUrl = "https://github.com/$Repo/releases/latest"
 
+    # Try GitHub Pages first (no rate limiting)
     try {
-        $redirectUrl = Invoke-WithRetry {
-            try {
-                $resp = Invoke-WebRequest -Uri $latestUrl -MaximumRedirection 0 -ErrorAction SilentlyContinue -UseBasicParsing
-                # PS7: no exception on redirect, check status
-                if ($resp.StatusCode -ge 300 -and $resp.StatusCode -lt 400) {
-                    $loc = $resp.Headers['Location']
-                    if ($loc -is [array]) { $loc = $loc[0] }
-                    return $loc
-                }
-                return $null
-            } catch {
-                # PS5 may throw on redirect; extract Location from the exception response
-                $exResp = $_.Exception.Response
-                if ($exResp) {
-                    $loc = $exResp.Headers['Location']
-                    if ($loc) { return $loc }
-                }
-                throw
-            }
-        }
-
-        if ($redirectUrl) {
-            $Version = ($redirectUrl -split '/')[-1]
-        }
+        $Version = (Invoke-WithRetry {
+            Invoke-RestMethod -Uri "https://metaplay.github.io/cli/latest-version.txt"
+        }).Trim()
+        Print-Verbose "Detected latest version from GitHub Pages: $Version"
     } catch {
-        Print-Verbose "Redirect method failed: $($_.Exception.Message)"
-    }
+        Print-Verbose "GitHub Pages method failed: $($_.Exception.Message)"
 
-    if (-not $Version) {
-        # Fallback: use the API
-        Print-Verbose 'Redirect method failed, falling back to GitHub API...'
+        # Fallback: use GitHub redirect
+        $latestUrl = "https://github.com/$Repo/releases/latest"
+
         try {
-            $releaseInfo = Invoke-WithRetry {
-                Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+            $redirectUrl = Invoke-WithRetry {
+                try {
+                    $resp = Invoke-WebRequest -Uri $latestUrl -MaximumRedirection 0 -ErrorAction SilentlyContinue -UseBasicParsing
+                    # PS7: no exception on redirect, check status
+                    if ($resp.StatusCode -ge 300 -and $resp.StatusCode -lt 400) {
+                        $loc = $resp.Headers['Location']
+                        if ($loc -is [array]) { $loc = $loc[0] }
+                        return $loc
+                    }
+                    return $null
+                } catch {
+                    # PS5 may throw on redirect; extract Location from the exception response
+                    $exResp = $_.Exception.Response
+                    if ($exResp) {
+                        $loc = $exResp.Headers['Location']
+                        if ($loc) { return $loc }
+                    }
+                    throw
+                }
             }
-            $Version = $releaseInfo.tag_name
-        } catch {
-            Print-Error "Failed to determine latest CLI version. Check your network connection."
-            Print-Error $_.Exception.Message
-            $script:InstallFailed = $true; return
-        }
-    }
 
-    Print-Verbose "Detected latest official version: $Version"
+            if ($redirectUrl) {
+                $Version = ($redirectUrl -split '/')[-1]
+            }
+        } catch {
+            Print-Verbose "Redirect method failed: $($_.Exception.Message)"
+        }
+
+        if (-not $Version) {
+            # Last resort: use the API
+            Print-Verbose 'Redirect method failed, falling back to GitHub API...'
+            try {
+                $releaseInfo = Invoke-WithRetry {
+                    Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+                }
+                $Version = $releaseInfo.tag_name
+            } catch {
+                Print-Error "Failed to determine latest CLI version. Check your network connection."
+                Print-Error $_.Exception.Message
+                $script:InstallFailed = $true; return
+            }
+        }
+
+        Print-Verbose "Detected latest official version: $Version"
+    }
 } elseif ($Version -eq 'latest-dev') {
     Print-Verbose "Version specified as 'latest-dev'. Finding latest development release..."
     try {

--- a/install.sh
+++ b/install.sh
@@ -127,24 +127,33 @@ print_verbose "OS: $OS"
 print_verbose "Arch: $ARCH"
 print_verbose "Install dir: $INSTALL_DIR"
 
-# If no VERSION specified, discover latest via GitHub API
+# If no VERSION specified, discover latest via GitHub Pages (avoids rate limits)
 if [ -z "$VERSION" ]; then
   print_verbose "No version specified. Finding latest official release..."
-  # Determine the latest version from the non-rate-limited URL (instead of api.github.com which is throttled).
-  # It responds with a 302 redirect to the latest release, e.g., https://github.com/metaplay/cli/releases/tag/1.4.4,
-  # which we then parse the actual version number from.
-  latest_release_url="https://github.com/${REPO}/releases/latest"
+
+  # Try GitHub Pages first (no rate limiting)
   curl_exit=0
-  redirect_url=$(curl -sI --show-error --fail --retry 10 --retry-all-errors --retry-max-time 60 -o /dev/null -w '%{redirect_url}' "$latest_release_url") || curl_exit=$?
+  VERSION=$(curl -sSfL --retry 10 --retry-all-errors --retry-max-time 60 "https://metaplay.github.io/cli/latest-version.txt") || curl_exit=$?
 
-  if [ $curl_exit -ne 0 ]; then
-    print_error "Failed to determine latest CLI version from $latest_release_url (curl exited with code $curl_exit)."
-    print_error "This is most likely a network issue. See curl output above for details."
-    exit 1
+  if [ $curl_exit -eq 0 ] && [ -n "$VERSION" ]; then
+    VERSION=$(printf '%s' "$VERSION" | tr -d '\n\r')
+    print_verbose "Detected latest version from GitHub Pages: $VERSION"
+  else
+    # Fallback: use GitHub redirect
+    print_verbose "GitHub Pages method failed, falling back to GitHub redirect..."
+    latest_release_url="https://github.com/${REPO}/releases/latest"
+    curl_exit=0
+    redirect_url=$(curl -sI --show-error --fail --retry 10 --retry-all-errors --retry-max-time 60 -o /dev/null -w '%{redirect_url}' "$latest_release_url") || curl_exit=$?
+
+    if [ $curl_exit -ne 0 ]; then
+      print_error "Failed to determine latest CLI version from $latest_release_url (curl exited with code $curl_exit)."
+      print_error "This is most likely a network issue. See curl output above for details."
+      exit 1
+    fi
+
+    VERSION="${redirect_url##*/}"
+    print_verbose "Detected latest official version: $VERSION"
   fi
-
-  VERSION="${redirect_url##*/}"
-  print_verbose "Detected latest official version: $VERSION"
 elif [ "$VERSION" = "latest-dev" ]; then
   print_verbose "Version specified as 'latest-dev'. Finding latest development release..."
   # Fetch all releases (newest first), get the tag_name of the very first one


### PR DESCRIPTION
Quick stab at printing the latest release into a file in the CDN and using that in the install script.

Kinda hacky. Maybe there's a better way and this can be closed.

## Summary

- Publish `latest-version.txt` via GitHub Pages in `publish-pages.yml`
- Update `install.sh` and `install.ps1` to fetch version from Pages first
- Fall back to GitHub redirect → GitHub API if Pages unavailable

This should fix intermittent HTTP failures in CI caused by GitHub's rate limiting on the `/releases/latest` redirect URL.