### PR TITLE
Pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           show-progress: false # suppress the noisy progress status output
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26'
 

--- a/.github/workflows/prune-old-dev-tags.yaml
+++ b/.github/workflows/prune-old-dev-tags.yaml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Tags must be available to the script, so fetch the full commit history
           show-progress: false # suppress noisy progress output
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Tags must be available for GoReleaser, so fetch the full commit history
           show-progress: false # suppress the noisy progress status output
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26'
 
@@ -45,7 +45,7 @@ jobs:
 
       # Dev builds are not published to distribution channels, only available in Github as draft releases
       - name: Run GoReleaser (Development Build)
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ env.NEXT_DEV_TAG }}

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Copy the install.sh to be available publicly at https://metaplay.github.io/cli/install.sh.
       # GitHub Pages isn't throttled like the https://raw.githubusercontent.com/metaplay/cli/main/install.sh.
@@ -38,16 +38,16 @@ jobs:
           cp install.ps1 site/
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: site
 
       - id: deployment
         name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
       - name: Show published URL
         run: echo "🎉 Site published at ${{ steps.deployment.outputs.page_url }}"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -20,19 +20,19 @@ jobs:
         run: echo "### Published version ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Tags must be available for GoReleaser, so fetch the full commit history
           show-progress: false # suppress the noisy progress status output
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26'
 
       - name: Fetch tokens from the vault
         id: secrets
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
         with:
           url: https://vault.int.metaplay.dev:8200
           path: github-actions
@@ -50,7 +50,7 @@ jobs:
           git tag -l '*-dev*' | ForEach-Object { git tag -d $_ }
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           METAPLAYBOT_GITHUB_TOKEN: ${{ steps.secrets.outputs.METAPLAYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/test-install-ps1.yaml
+++ b/.github/workflows/test-install-ps1.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Lint
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
@@ -42,7 +42,7 @@ jobs:
         shell: [pwsh, powershell]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Clean pre-existing installation
         run: |
@@ -117,7 +117,7 @@ jobs:
         shell: [pwsh, powershell]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Clean pre-existing installation
         run: |
@@ -160,7 +160,7 @@ jobs:
     name: "-Help flag"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Verify -Help exits successfully and prints usage
         shell: pwsh
         run: |
@@ -175,7 +175,7 @@ jobs:
     name: "Error produces non-zero exit code"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Verify unsupported architecture fails with exit code 1
         shell: pwsh
         run: |

--- a/.github/workflows/test-install-sh.yaml
+++ b/.github/workflows/test-install-sh.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run shellcheck
         run: shellcheck --severity=warning --exclude=SC2034 install.sh
 
@@ -33,7 +33,7 @@ jobs:
         shell: [bash, zsh, fish]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install shell (Ubuntu)
         if: matrix.os == 'ubuntu-latest' && matrix.shell != 'bash'
@@ -125,7 +125,7 @@ jobs:
     name: "Fallback when SHELL is unset"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Prepare environment
         run: |


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions to full commit SHAs for supply chain security
- Uses Renovate-compatible `owner/repo@sha # tag` syntax so Renovate can still auto-update

## Actions pinned
| Action | Tag |
|--------|-----|
| `actions/checkout` | v6 |
| `actions/setup-go` | v6 |
| `actions/setup-python` | v6 |
| `actions/configure-pages` | v6 |
| `actions/upload-pages-artifact` | v4 |
| `actions/deploy-pages` | v5 |
| `goreleaser/goreleaser-action` | v7 |
| `hashicorp/vault-action` | v3 |