### PR TITLE
Add prerelease update channel support (mainly for internal use)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,20 @@ If you have a paid support contract with Metaplay, you can open a ticket on the 
 
 We continuously create development builds from the `metaplay/cli` repository `main` branch. These builds are tagged with a `-dev.N` suffix (e.g., `1.2.4-dev.1`) and published as draft releases. You can find the latest development build on the main [releases page](https://github.com/metaplay/cli/releases). The development builds are primarily intended for testing purposes and should generally not be used.
 
-Development builds do not currently perform any version checks (for the purpose of new release notifications), and the `update cli` command is disabled on development builds as well. If you need to override this behavior, you can mock up a specific version number with the following:
+#### Update Channels
+
+The CLI has two update channels:
+
+- **GA channel** — used by official releases (e.g., `1.2.3`). Shows an update banner when a newer GA release is available.
+- **Prerelease channel** — prerelease builds (e.g., `1.2.3-dev.5`). Automatically updates to the latest prerelease on every run (except in CI environments).
+
+To switch a GA build to the prerelease channel, run:
 
 ```bash
-cli$ go build -ldflags="-X 'github.com/metaplay/cli/internal/version.AppVersion=<major.minor.patch>'" .
+metaplay update cli --prerelease
 ```
 
-It is highly recommended to use the latest official release, so should you decide to mess with development builds, proceed with extreme caution!
+This also works with locally built `dev` version to upgrade it to the prerelease channel.
 
 #### Build Locally
 

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -45,19 +45,28 @@ func (l selfupdateLogger) Printf(format string, v ...interface{}) {
 }
 
 func (o *updateCliOpts) Run(cmd *cobra.Command) error {
-	log.Info().Msg("")
-	log.Info().Msgf("Resolving the latest Metaplay CLI version...")
-
-	// Forward go-selfupdate outputs to console on debug level.
 	selfupdate.SetLogger(selfupdateLogger{})
+
+	prerelease := version.IsPrerelease() || version.IsDevBuild()
+	if prerelease {
+		log.Info().Msgf("Checking for the latest Metaplay CLI prerelease version...")
+	} else {
+		log.Info().Msgf("Checking for the latest Metaplay CLI version...")
+	}
 
 	source, err := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to initialize the Metaplay CLI updater source: %w", err)
 	}
 
+	var updateSource selfupdate.Source = source
+	if prerelease {
+		updateSource = &version.PrereleaseOnlySource{Inner: updateSource}
+	}
+
 	updater, err := selfupdate.NewUpdater(selfupdate.Config{
-		Source: source,
+		Source:     updateSource,
+		Prerelease: prerelease,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize the Metaplay CLI updater: %w", err)

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -16,7 +16,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type updateCliOpts struct{}
+type updateCliOpts struct {
+	flagPrerelease bool
+}
 
 func init() {
 	o := updateCliOpts{}
@@ -26,6 +28,8 @@ func init() {
 		Short: "Update the Metaplay CLI to the latest version",
 		Run:   runCommand(&o),
 	}
+
+	cmd.Flags().BoolVar(&o.flagPrerelease, "prerelease", false, "Update to the latest prerelease version")
 
 	updateCmd.AddCommand(cmd)
 }
@@ -47,7 +51,7 @@ func (l selfupdateLogger) Printf(format string, v ...interface{}) {
 func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 	selfupdate.SetLogger(selfupdateLogger{})
 
-	prerelease := version.IsPrerelease() || version.IsDevBuild()
+	prerelease := o.flagPrerelease || version.IsPrerelease() || version.IsDevBuild()
 	if prerelease {
 		log.Info().Msgf("Checking for the latest Metaplay CLI prerelease version...")
 	} else {

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -40,11 +40,11 @@ func (o *updateCliOpts) Prepare(cmd *cobra.Command, args []string) error {
 
 type selfupdateLogger struct{}
 
-func (l selfupdateLogger) Print(v ...interface{}) {
+func (l selfupdateLogger) Print(v ...any) {
 	log.Debug().Msgf("%v", v...)
 }
 
-func (l selfupdateLogger) Printf(format string, v ...interface{}) {
+func (l selfupdateLogger) Printf(format string, v ...any) {
 	log.Debug().Msgf(format, v...)
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -52,7 +52,7 @@ func (o *versionOpts) Run(cmd *cobra.Command) error {
 		info := VersionInfo{
 			AppVersion: version.AppVersion,
 			GitCommit:  version.GitCommit,
-			Prerelease: version.IsDevBuild(),
+			Prerelease: version.IsPrerelease(),
 		}
 
 		// Marshal to JSON.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -52,7 +52,7 @@ func (o *versionOpts) Run(cmd *cobra.Command) error {
 		info := VersionInfo{
 			AppVersion: version.AppVersion,
 			GitCommit:  version.GitCommit,
-			Prerelease: version.IsPrerelease(),
+			Prerelease: version.IsPrerelease() || version.IsDevBuild(),
 		}
 
 		// Marshal to JSON.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -29,9 +29,8 @@ func IsDevBuild() bool {
 	return AppVersion == devBuild
 }
 
-// IsPrerelease returns true if the current version should use the prerelease
-// update channel. This includes both prerelease builds (e.g. "0.1.3-dev.5")
-// and local development builds ("dev").
+// IsPrerelease returns true if the current version is a prerelease build
+// (e.g. "0.1.3-dev.5"), but not a local development build ("dev").
 func IsPrerelease() bool {
 	return strings.Contains(AppVersion, "-dev.")
 }
@@ -128,27 +127,28 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 	}
 
 	// GA builds: show update banner.
-	topBorder := "╭──────────────────────────────────────────────────────────────────╮"
-	bottomBorder := "╰──────────────────────────────────────────────────────────────────╯"
-	emptyLine := "│                                                                  │"
+	updateLine := fmt.Sprintf("Update available! %s → %s", AppVersion, latest.Version())
+	commandLine := "To update, run: metaplay update cli"
 
-	padding := strings.Repeat(" ", 41-len(AppVersion)-len(latest.Version()))
-	updateText := fmt.Sprintf("│  %s %s → %s %s │",
+	// Determine inner width based on the longest content line.
+	innerWidth := max(len(updateLine), len(commandLine)) + 4 // 2 chars padding on each side
+
+	pad := func(visibleLen int) string {
+		return strings.Repeat(" ", innerWidth-2-visibleLen)
+	}
+
+	stderrLogger.Info().Msgf("╭%s╮", strings.Repeat("─", innerWidth))
+	stderrLogger.Info().Msgf("│%s│", strings.Repeat(" ", innerWidth))
+	stderrLogger.Info().Msgf("│  %s %s → %s%s│",
 		"Update available!",
 		styles.RenderError(AppVersion),
 		styles.RenderSuccess(latest.Version()),
-		padding,
+		pad(len(updateLine)),
 	)
-
-	commandText := fmt.Sprintf("│  To update, run: %s %s │",
-		styles.RenderPrompt("metaplay update cli"),
-		strings.Repeat(" ", 27),
+	stderrLogger.Info().Msgf("│  %s%s│",
+		styles.RenderPrompt("To update, run: metaplay update cli"),
+		pad(len(commandLine)),
 	)
-
-	stderrLogger.Info().Msg(topBorder)
-	stderrLogger.Info().Msg(emptyLine)
-	stderrLogger.Info().Msg(updateText)
-	stderrLogger.Info().Msg(commandText)
-	stderrLogger.Info().Msg(emptyLine)
-	stderrLogger.Info().Msg(bottomBorder)
+	stderrLogger.Info().Msgf("│%s│", strings.Repeat(" ", innerWidth))
+	stderrLogger.Info().Msgf("╰%s╯", strings.Repeat("─", innerWidth))
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/creativeprojects/go-selfupdate"
+	"github.com/metaplay/cli/internal/envutil"
+	"github.com/metaplay/cli/internal/pathutil"
 	"github.com/metaplay/cli/pkg/styles"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -93,29 +95,51 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 		return
 	}
 
-	if found && latest.GreaterThan(AppVersion) {
-		topBorder := "╭──────────────────────────────────────────────────────────────────╮"
-		bottomBorder := "╰──────────────────────────────────────────────────────────────────╯"
-		emptyLine := "│                                                                  │"
+	if !found || !latest.GreaterThan(AppVersion) {
+		return
+	}
 
-		padding := strings.Repeat(" ", 41-len(AppVersion)-len(latest.Version()))
-		updateText := fmt.Sprintf("│  %s %s → %s %s │",
-			"Update available!",
+	// Auto-update prerelease/dev builds (except in CI).
+	if usePrerelease && !envutil.IsCI() {
+		stderrLogger.Info().Msgf("Auto-updating CLI from %s to %s...",
 			styles.RenderError(AppVersion),
 			styles.RenderSuccess(latest.Version()),
-			padding,
 		)
-
-		commandText := fmt.Sprintf("│  To update, run: %s %s │",
-			styles.RenderPrompt("metaplay update cli"),
-			strings.Repeat(" ", 27),
-		)
-
-		stderrLogger.Info().Msg(topBorder)
-		stderrLogger.Info().Msg(emptyLine)
-		stderrLogger.Info().Msg(updateText)
-		stderrLogger.Info().Msg(commandText)
-		stderrLogger.Info().Msg(emptyLine)
-		stderrLogger.Info().Msg(bottomBorder)
+		exe, err := pathutil.GetExecutablePath()
+		if err != nil {
+			log.Debug().Msgf("Auto-update failed: could not determine executable path: %v", err)
+			return
+		}
+		if err := updater.UpdateTo(context.Background(), latest, exe); err != nil {
+			log.Debug().Msgf("Auto-update failed: %v", err)
+			return
+		}
+		stderrLogger.Info().Msgf(styles.RenderSuccess("Updated CLI to %s.") + " Note: this command is still running with the previous version.", latest.Version())
+		return
 	}
+
+	// GA builds: show update banner.
+	topBorder := "╭──────────────────────────────────────────────────────────────────╮"
+	bottomBorder := "╰──────────────────────────────────────────────────────────────────╯"
+	emptyLine := "│                                                                  │"
+
+	padding := strings.Repeat(" ", 41-len(AppVersion)-len(latest.Version()))
+	updateText := fmt.Sprintf("│  %s %s → %s %s │",
+		"Update available!",
+		styles.RenderError(AppVersion),
+		styles.RenderSuccess(latest.Version()),
+		padding,
+	)
+
+	commandText := fmt.Sprintf("│  To update, run: %s %s │",
+		styles.RenderPrompt("metaplay update cli"),
+		strings.Repeat(" ", 27),
+	)
+
+	stderrLogger.Info().Msg(topBorder)
+	stderrLogger.Info().Msg(emptyLine)
+	stderrLogger.Info().Msg(updateText)
+	stderrLogger.Info().Msg(commandText)
+	stderrLogger.Info().Msg(emptyLine)
+	stderrLogger.Info().Msg(bottomBorder)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -62,6 +62,11 @@ func (s *PrereleaseOnlySource) DownloadReleaseAsset(ctx context.Context, rel *se
 }
 
 func CheckVersion(stderrLogger *zerolog.Logger) {
+	if IsDevBuild() {
+		log.Debug().Msgf("Skipping version check for development build (version is '%s')", AppVersion)
+		return
+	}
+
 	log.Debug().Msgf("Checking for new CLI version (current: v%s)", AppVersion)
 
 	// Check for new releases using go-selfupdate.
@@ -95,11 +100,15 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 		return
 	}
 
-	if !found || !latest.GreaterThan(AppVersion) {
+	if !found {
 		return
 	}
 
-	// Auto-update prerelease/dev builds (except in CI).
+	if !latest.GreaterThan(AppVersion) {
+		return
+	}
+
+	// Auto-update prerelease builds (except in CI).
 	if usePrerelease && !envutil.IsCI() {
 		stderrLogger.Info().Msgf("Auto-updating CLI from %s to %s...",
 			styles.RenderError(AppVersion),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,6 +7,7 @@ package version
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/creativeprojects/go-selfupdate"
@@ -26,17 +27,44 @@ func IsDevBuild() bool {
 	return AppVersion == devBuild
 }
 
-func CheckVersion(stderrLogger *zerolog.Logger) {
-	if IsDevBuild() {
-		log.Debug().Msgf("Bypassing self-updater version checks for development builds (version is '%s')", AppVersion)
-		return
-	}
+// IsPrerelease returns true if the current version should use the prerelease
+// update channel. This includes both prerelease builds (e.g. "0.1.3-dev.5")
+// and local development builds ("dev").
+func IsPrerelease() bool {
+	return strings.Contains(AppVersion, "-dev.")
+}
 
+// PrereleaseOnlySource wraps a Source and filters ListReleases to only return
+// prerelease releases. This ensures the updater stays on the prerelease channel
+// and won't "upgrade" to a GA release.
+type PrereleaseOnlySource struct {
+	Inner selfupdate.Source
+}
+
+func (s *PrereleaseOnlySource) ListReleases(ctx context.Context, repository selfupdate.Repository) ([]selfupdate.SourceRelease, error) {
+	releases, err := s.Inner.ListReleases(ctx, repository)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]selfupdate.SourceRelease, 0, len(releases))
+	for _, r := range releases {
+		if r.GetPrerelease() {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered, nil
+}
+
+func (s *PrereleaseOnlySource) DownloadReleaseAsset(ctx context.Context, rel *selfupdate.Release, assetID int64) (io.ReadCloser, error) {
+	return s.Inner.DownloadReleaseAsset(ctx, rel, assetID)
+}
+
+func CheckVersion(stderrLogger *zerolog.Logger) {
 	log.Debug().Msgf("Checking for new CLI version (current: v%s)", AppVersion)
 
 	// Check for new releases using go-selfupdate.
 	// Errors are only logged, not fatal, in order to allow the command to run even if the version check fails.
-	source, err := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{
+	ghSource, err := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{
 		APIToken: "", // Public repo doesn't need auth
 	})
 	if err != nil {
@@ -44,8 +72,15 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 		return
 	}
 
+	var source selfupdate.Source = ghSource
+	usePrerelease := IsPrerelease() || IsDevBuild()
+	if usePrerelease {
+		source = &PrereleaseOnlySource{Inner: source}
+	}
+
 	updater, err := selfupdate.NewUpdater(selfupdate.Config{
-		Source: source,
+		Source:     source,
+		Prerelease: usePrerelease,
 	})
 	if err != nil {
 		log.Debug().Msg("Error: Failed to initialize the Metaplay CLI self-updater")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/metaplay/cli/internal/envutil"
@@ -127,28 +128,40 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 	}
 
 	// GA builds: show update banner.
-	updateLine := fmt.Sprintf("Update available! %s → %s", AppVersion, latest.Version())
+	for _, line := range renderUpdateBanner(AppVersion, latest.Version()) {
+		stderrLogger.Info().Msg(line)
+	}
+}
+
+// renderUpdateBanner builds the bordered update notification box.
+// currentVersion and latestVersion are plain version strings (no ANSI).
+func renderUpdateBanner(currentVersion, latestVersion string) []string {
+	updateLine := fmt.Sprintf("Update available! %s → %s", currentVersion, latestVersion)
 	commandLine := "To update, run: metaplay update cli"
 
-	// Determine inner width based on the longest content line.
-	innerWidth := max(len(updateLine), len(commandLine)) + 4 // 2 chars padding on each side
+	// Inner width (in runes) = longest content line + 4 (2 chars padding each side).
+	updateWidth := utf8.RuneCountInString(updateLine)
+	commandWidth := utf8.RuneCountInString(commandLine)
+	innerWidth := max(updateWidth, commandWidth) + 4
 
-	pad := func(visibleLen int) string {
-		return strings.Repeat(" ", innerWidth-2-visibleLen)
+	pad := func(visibleWidth int) string {
+		return strings.Repeat(" ", innerWidth-2-visibleWidth)
 	}
 
-	stderrLogger.Info().Msgf("╭%s╮", strings.Repeat("─", innerWidth))
-	stderrLogger.Info().Msgf("│%s│", strings.Repeat(" ", innerWidth))
-	stderrLogger.Info().Msgf("│  %s %s → %s%s│",
-		"Update available!",
-		styles.RenderError(AppVersion),
-		styles.RenderSuccess(latest.Version()),
-		pad(len(updateLine)),
-	)
-	stderrLogger.Info().Msgf("│  %s%s│",
-		styles.RenderPrompt("To update, run: metaplay update cli"),
-		pad(len(commandLine)),
-	)
-	stderrLogger.Info().Msgf("│%s│", strings.Repeat(" ", innerWidth))
-	stderrLogger.Info().Msgf("╰%s╯", strings.Repeat("─", innerWidth))
+	return []string{
+		fmt.Sprintf("╭%s╮", strings.Repeat("─", innerWidth)),
+		fmt.Sprintf("│%s│", strings.Repeat(" ", innerWidth)),
+		fmt.Sprintf("│  %s %s → %s%s│",
+			"Update available!",
+			styles.RenderError(currentVersion),
+			styles.RenderSuccess(latestVersion),
+			pad(updateWidth),
+		),
+		fmt.Sprintf("│  %s%s│",
+			styles.RenderPrompt("To update, run: metaplay update cli"),
+			pad(commandWidth),
+		),
+		fmt.Sprintf("│%s│", strings.Repeat(" ", innerWidth)),
+		fmt.Sprintf("╰%s╯", strings.Repeat("─", innerWidth)),
+	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -80,7 +80,7 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 	}
 
 	var source selfupdate.Source = ghSource
-	usePrerelease := IsPrerelease() || IsDevBuild()
+	usePrerelease := IsPrerelease()
 	if usePrerelease {
 		source = &PrereleaseOnlySource{Inner: source}
 	}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,113 @@
+package version
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestIsDevBuild(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"dev", true},
+		{"1.2.3", false},
+		{"1.2.3-dev.5", false},
+	}
+	for _, tt := range tests {
+		AppVersion = tt.version
+		if got := IsDevBuild(); got != tt.want {
+			t.Errorf("IsDevBuild() with version %q = %v, want %v", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestIsPrerelease(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"dev", false},
+		{"1.2.3", false},
+		{"1.2.3-dev.5", true},
+		{"0.1.0-dev.1", true},
+		{"1.2.3-beta.1", false},
+	}
+	for _, tt := range tests {
+		AppVersion = tt.version
+		if got := IsPrerelease(); got != tt.want {
+			t.Errorf("IsPrerelease() with version %q = %v, want %v", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestRenderUpdateBanner(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+	}{
+		{"short versions", "1.0.0", "1.1.0"},
+		{"long prerelease versions", "1.2.3-dev.100", "1.2.4-dev.200"},
+		{"asymmetric lengths", "0.1.0", "10.20.30-dev.999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := renderUpdateBanner(tt.currentVersion, tt.latestVersion)
+
+			if len(lines) != 6 {
+				t.Fatalf("expected 6 lines, got %d", len(lines))
+			}
+
+			// Strip ANSI escape codes to measure visual width.
+			stripANSI := func(s string) string {
+				var out strings.Builder
+				inEscape := false
+				for _, r := range s {
+					if r == '\x1b' {
+						inEscape = true
+						continue
+					}
+					if inEscape {
+						if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+							inEscape = false
+						}
+						continue
+					}
+					out.WriteRune(r)
+				}
+				return out.String()
+			}
+
+			// All lines should have the same visual width.
+			widths := make([]int, len(lines))
+			for i, line := range lines {
+				widths[i] = utf8.RuneCountInString(stripANSI(line))
+			}
+			for i := 1; i < len(widths); i++ {
+				if widths[i] != widths[0] {
+					t.Errorf("line %d width %d != line 0 width %d\n  line 0: %s\n  line %d: %s",
+						i, widths[i], widths[0], stripANSI(lines[0]), i, stripANSI(lines[i]))
+				}
+			}
+
+			// First and last lines should be borders.
+			first := stripANSI(lines[0])
+			if !strings.HasPrefix(first, "╭") || !strings.HasSuffix(first, "╮") {
+				t.Errorf("first line should be top border, got: %s", first)
+			}
+			last := stripANSI(lines[5])
+			if !strings.HasPrefix(last, "╰") || !strings.HasSuffix(last, "╯") {
+				t.Errorf("last line should be bottom border, got: %s", last)
+			}
+
+			// Content lines should contain the version strings.
+			content := stripANSI(lines[2])
+			if !strings.Contains(content, tt.currentVersion) || !strings.Contains(content, tt.latestVersion) {
+				t.Errorf("update line should contain both versions, got: %s", content)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add prerelease update channel: prerelease builds (`x.y.z-dev.N`) auto-update to the latest prerelease on every CLI run (except in CI)
- Add `--prerelease` flag to `metaplay update cli` to switch from GA to the prerelease channel
- Fix panic when running version check on dev builds (`AppVersion` = `"dev"` is not valid semver)
- Refactor update banner into `renderUpdateBanner()` with dynamic width calculation and add tests

## Test plan
- [x] Run `metaplay version` on a dev build — should not panic
- [x] Run `metaplay update cli --prerelease` — should find and install latest prerelease
- [x] Run a prerelease build — should auto-update to latest prerelease
- [x] Run a GA build — should show update banner if newer GA exists, no auto-update
- [x] Verify `go test ./internal/version/...` passes