### PR TITLE
Fix: support no response from adminapi

### DIFF
--- a/cmd/debug_admin_request.go
+++ b/cmd/debug_admin_request.go
@@ -167,6 +167,8 @@ func (o *debugAdminRequestOpts) Run(cmd *cobra.Command) error {
 		// Detect if passed string is JSON, otherwise fallback to default resty behavior
 		if o.flagContentType == "" && IsJSON(o.flagBody) {
 			contentType = "application/json"
+		} else if o.flagContentType == "application/json" && !IsJSON(o.flagBody) {
+			log.Warn().Msg(styles.RenderWarning("⚠️ Content-Type is application/json but --body does not appear to be valid JSON"))
 		}
 	} else if o.flagFile != "" {
 		// Read content from file

--- a/cmd/debug_admin_request.go
+++ b/cmd/debug_admin_request.go
@@ -251,6 +251,12 @@ func (o *debugAdminRequestOpts) Run(cmd *cobra.Command) error {
 		return fmt.Errorf("request failed: %v", requestErr)
 	}
 
+	// If no response body was returned, print something to acknowledge the result
+	if response == nil {
+		log.Info().Msg(styles.RenderSuccess("✅ Request successful!"))
+		return nil
+	}
+
 	// Format and display the response
 	log.Debug().Msg(styles.RenderSuccess("✅ Request successful!"))
 	log.Debug().Msg("")

--- a/pkg/metahttp/metahttp.go
+++ b/pkg/metahttp/metahttp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -187,12 +188,18 @@ func Request[TResponse any](c *Client, method string, url string, body any, cont
 	} else {
 		// For complex types, get the body as JSON and unmarshal into TResult.
 		rawBody := response.Body()
-		err = json.Unmarshal(rawBody, &result)
-		if err != nil {
-			log.Error().Msgf("Failed to unmarshal response: %v, raw body: %s", err, rawBody)
-			return result, err
+		if len(rawBody) == 0 {
+			// Empty body is only valid when TResponse is any (interface{}); all other types require a response body.
+			if reflect.TypeOf((*TResponse)(nil)).Elem().Kind() != reflect.Interface {
+				return result, fmt.Errorf("server returned an empty response body where JSON was expected")
+			}
+		} else {
+			err = json.Unmarshal(rawBody, &result)
+			if err != nil {
+				log.Error().Msgf("Failed to unmarshal response: %v, raw body: %s", err, rawBody)
+				return result, err
+			}
 		}
-
 	}
 
 	return result, nil


### PR DESCRIPTION
* Make MetaHTTP helper support server returning no data, but only if the generic TResponse is `any`. In this case, the method returns nil. Only admin-request uses `any`.
* In admin-request handler, handle http helper returning nil.
* chore: add extra warning if alleged json params are not json. Easy to mess with shell escape fighting you. Helps debug Bad Requests.