### PR TITLE
feat(metahttp): return typed HTTPError for non-2xx responses

### DIFF
--- a/pkg/metahttp/metahttp.go
+++ b/pkg/metahttp/metahttp.go
@@ -27,6 +27,43 @@ type Client struct {
 	Resty    *resty.Client  // Resty client with authorization header configured.
 }
 
+// HTTPError is returned by Request (and its Get/Post/Put/Delete helpers) when
+// the server responds with a non-2xx status code. Callers can use errors.As to
+// detect HTTP errors and inspect the status code and parsed message for
+// discrimination and user-friendly messaging.
+type HTTPError struct {
+	StatusCode int    // HTTP status code returned by the server (e.g., 400, 404, 409, 500)
+	Method     string // HTTP method used for the request (e.g., "GET", "POST")
+	URL        string // Full request URL (base URL + path)
+	Body       []byte // Raw response body
+	Message    string // Parsed error message from the response body, or empty if none could be parsed
+}
+
+// Error implements the error interface.
+func (e *HTTPError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%s %s failed with status %d: %s", e.Method, e.URL, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("%s %s failed with status %d", e.Method, e.URL, e.StatusCode)
+}
+
+// parseHTTPErrorMessage extracts a user-readable error message from an HTTP
+// error response body. Expects a JSON body of the form {"error": "..."} (the
+// StackAPI error shape); falls back to the raw body as a trimmed string when
+// JSON parsing fails or no "error" field is present.
+func parseHTTPErrorMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Error != "" {
+		return parsed.Error
+	}
+	return strings.TrimSpace(string(body))
+}
+
 // NewJSONClient creates a new HTTP client with the given auth token set and base URL.
 // All failed requests are automatically retried a few times to mitigate network errors.
 func NewJSONClient(tokenSet *auth.TokenSet, baseURL string) *Client {
@@ -174,11 +211,17 @@ func Request[TResponse any](c *Client, method string, url string, body any, cont
 
 	// Check response status code
 	if response.StatusCode() < http.StatusOK || response.StatusCode() >= http.StatusMultipleChoices {
-		// Print error details before return the error to keep the log more readable.
-		errorBody := string(response.Body())
+		// Print error details before returning the error to keep the log more readable.
+		errorBody := response.Body()
 		requestURL := fmt.Sprintf("%s%s", c.BaseURL, url)
-		log.Error().Msgf("Request failed with status code %d (%s %s): %s", response.StatusCode(), method, requestURL, errorBody)
-		return result, fmt.Errorf("%s %s failed (see above for details)", method, requestURL)
+		log.Error().Msgf("Request failed with status code %d (%s %s): %s", response.StatusCode(), method, requestURL, string(errorBody))
+		return result, &HTTPError{
+			StatusCode: response.StatusCode(),
+			Method:     method,
+			URL:        requestURL,
+			Body:       errorBody,
+			Message:    parseHTTPErrorMessage(errorBody),
+		}
 	}
 
 	// If type TResult is just string, get the body of the HTTP response as plaintext

--- a/pkg/metahttp/metahttp.go
+++ b/pkg/metahttp/metahttp.go
@@ -48,20 +48,29 @@ func (e *HTTPError) Error() string {
 }
 
 // parseHTTPErrorMessage extracts a user-readable error message from an HTTP
-// error response body. Expects a JSON body of the form {"error": "..."} (the
-// StackAPI error shape); falls back to the raw body as a trimmed string when
-// JSON parsing fails or no "error" field is present.
-func parseHTTPErrorMessage(body []byte) string {
+// error response body. Returns the message plus a boolean indicating whether
+// the body parsed cleanly as the expected structured error shape
+// {"error": "..."} with a non-empty error field.
+//
+// Structured responses are produced by handlers that opt into the shared
+// error-response contract used by the Metaplay backend APIs. Opaque
+// responses (different JSON shape, plain text, HTML from a proxy, empty,
+// ...) fall back to the trimmed raw body so callers still have something
+// human-readable to display. The structured flag lets callers (in
+// particular metahttp.Request) decide whether the raw error body is
+// redundant with the typed error or whether it carries information the
+// user still needs to see in the default output.
+func parseHTTPErrorMessage(body []byte) (string, bool) {
 	if len(body) == 0 {
-		return ""
+		return "", false
 	}
 	var parsed struct {
 		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Error != "" {
-		return parsed.Error
+		return parsed.Error, true
 	}
-	return strings.TrimSpace(string(body))
+	return strings.TrimSpace(string(body)), false
 }
 
 // NewJSONClient creates a new HTTP client with the given auth token set and base URL.
@@ -211,16 +220,30 @@ func Request[TResponse any](c *Client, method string, url string, body any, cont
 
 	// Check response status code
 	if response.StatusCode() < http.StatusOK || response.StatusCode() >= http.StatusMultipleChoices {
-		// Print error details before returning the error to keep the log more readable.
 		errorBody := response.Body()
 		requestURL := fmt.Sprintf("%s%s", c.BaseURL, url)
-		log.Error().Msgf("Request failed with status code %d (%s %s): %s", response.StatusCode(), method, requestURL, string(errorBody))
+		parsedMessage, structured := parseHTTPErrorMessage(errorBody)
+
+		// If the body parses as the expected {"error": "..."} JSON shape,
+		// the caller has everything it needs in the typed *HTTPError to
+		// produce a clean user-facing error, so emit the raw log only at
+		// Debug level to avoid doubling the output. Otherwise the body is
+		// opaque (unknown format, HTML intercepted by a proxy, legacy
+		// endpoints, ...) and the user's only reliable diagnostic signal
+		// is the raw log, so keep it at Error level.
+		rawLogLine := fmt.Sprintf("Request failed with status code %d (%s %s): %s", response.StatusCode(), method, requestURL, string(errorBody))
+		if structured {
+			log.Debug().Msg(rawLogLine)
+		} else {
+			log.Error().Msg(rawLogLine)
+		}
+
 		return result, &HTTPError{
 			StatusCode: response.StatusCode(),
 			Method:     method,
 			URL:        requestURL,
 			Body:       errorBody,
-			Message:    parseHTTPErrorMessage(errorBody),
+			Message:    parsedMessage,
 		}
 	}
 

--- a/pkg/metahttp/metahttp_test.go
+++ b/pkg/metahttp/metahttp_test.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package metahttp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/metaplay/cli/pkg/auth"
+)
+
+// newTestClient returns a metahttp.Client pointed at the given test server.
+func newTestClient(baseURL string) *Client {
+	return NewJSONClient(&auth.TokenSet{AccessToken: "test-token"}, baseURL)
+}
+
+func TestRequest_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"ok"}`))
+	}))
+	defer server.Close()
+
+	type response struct {
+		Message string `json:"message"`
+	}
+	got, err := Get[response](newTestClient(server.URL), "/ping")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if got.Message != "ok" {
+		t.Errorf("expected message %q, got %q", "ok", got.Message)
+	}
+}
+
+func TestRequest_HTTPError_400ParsedMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid shard index 5: environment has 1 shard(s)"}`))
+	}))
+	defer server.Close()
+
+	type response struct{}
+	_, err := Get[response](newTestClient(server.URL), "/things")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected StatusCode 400, got %d", httpErr.StatusCode)
+	}
+	if httpErr.Method != http.MethodGet {
+		t.Errorf("expected Method GET, got %q", httpErr.Method)
+	}
+	if httpErr.URL != server.URL+"/things" {
+		t.Errorf("expected URL %q, got %q", server.URL+"/things", httpErr.URL)
+	}
+	if httpErr.Message != "invalid shard index 5: environment has 1 shard(s)" {
+		t.Errorf("expected parsed message, got %q", httpErr.Message)
+	}
+}
+
+func TestRequest_HTTPError_404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"snapshot not found: foo"}`))
+	}))
+	defer server.Close()
+
+	type response struct{}
+	_, err := Get[response](newTestClient(server.URL), "/missing")
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected StatusCode 404, got %d", httpErr.StatusCode)
+	}
+	if httpErr.Message != "snapshot not found: foo" {
+		t.Errorf("unexpected message: %q", httpErr.Message)
+	}
+}
+
+func TestRequest_HTTPError_409(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"manual snapshot quota exceeded: 5/5 snapshots for this shard"}`))
+	}))
+	defer server.Close()
+
+	type response struct{}
+	_, err := PostJSON[response](newTestClient(server.URL), "/snapshots", map[string]any{"shardIndex": 0})
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusConflict {
+		t.Errorf("expected StatusCode 409, got %d", httpErr.StatusCode)
+	}
+	if httpErr.Method != http.MethodPost {
+		t.Errorf("expected Method POST, got %q", httpErr.Method)
+	}
+	if httpErr.Message != "manual snapshot quota exceeded: 5/5 snapshots for this shard" {
+		t.Errorf("unexpected message: %q", httpErr.Message)
+	}
+}
+
+func TestRequest_HTTPError_500_NonJSONBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream blew up\n"))
+	}))
+	defer server.Close()
+
+	type response struct{}
+	_, err := Get[response](newTestClient(server.URL), "/boom")
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected StatusCode 500, got %d", httpErr.StatusCode)
+	}
+	// Non-JSON body should fall back to the raw body (trimmed).
+	if httpErr.Message != "upstream blew up" {
+		t.Errorf("expected fallback to raw body, got %q", httpErr.Message)
+	}
+}
+
+func TestRequest_HTTPError_EmptyBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	type response struct{}
+	_, err := Get[response](newTestClient(server.URL), "/nothing")
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected StatusCode 502, got %d", httpErr.StatusCode)
+	}
+	if httpErr.Message != "" {
+		t.Errorf("expected empty message for empty body, got %q", httpErr.Message)
+	}
+}
+
+func TestHTTPError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *HTTPError
+		want string
+	}{
+		{
+			name: "with message",
+			err:  &HTTPError{StatusCode: 409, Method: "POST", URL: "https://example.com/x", Message: "quota exceeded"},
+			want: "POST https://example.com/x failed with status 409: quota exceeded",
+		},
+		{
+			name: "without message",
+			err:  &HTTPError{StatusCode: 502, Method: "GET", URL: "https://example.com/x"},
+			want: "GET https://example.com/x failed with status 502",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseHTTPErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{"empty", []byte(""), ""},
+		{"nil", nil, ""},
+		{"json with error field", []byte(`{"error":"bad thing"}`), "bad thing"},
+		{"json without error field", []byte(`{"foo":"bar"}`), `{"foo":"bar"}`},
+		{"non-json plain text", []byte("oops\n"), "oops"},
+		{"json with empty error", []byte(`{"error":""}`), `{"error":""}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseHTTPErrorMessage(tc.body); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/metahttp/metahttp_test.go
+++ b/pkg/metahttp/metahttp_test.go
@@ -184,21 +184,27 @@ func TestHTTPError_Error(t *testing.T) {
 
 func TestParseHTTPErrorMessage(t *testing.T) {
 	tests := []struct {
-		name string
-		body []byte
-		want string
+		name           string
+		body           []byte
+		wantMsg        string
+		wantStructured bool
 	}{
-		{"empty", []byte(""), ""},
-		{"nil", nil, ""},
-		{"json with error field", []byte(`{"error":"bad thing"}`), "bad thing"},
-		{"json without error field", []byte(`{"foo":"bar"}`), `{"foo":"bar"}`},
-		{"non-json plain text", []byte("oops\n"), "oops"},
-		{"json with empty error", []byte(`{"error":""}`), `{"error":""}`},
+		{"empty", []byte(""), "", false},
+		{"nil", nil, "", false},
+		{"json with error field", []byte(`{"error":"bad thing"}`), "bad thing", true},
+		{"json without error field", []byte(`{"foo":"bar"}`), `{"foo":"bar"}`, false},
+		{"non-json plain text", []byte("oops\n"), "oops", false},
+		{"json with empty error", []byte(`{"error":""}`), `{"error":""}`, false},
+		{"html from proxy", []byte("<html><body>502 Bad Gateway</body></html>"), "<html><body>502 Bad Gateway</body></html>", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := parseHTTPErrorMessage(tc.body); got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
+			gotMsg, gotStructured := parseHTTPErrorMessage(tc.body)
+			if gotMsg != tc.wantMsg {
+				t.Errorf("msg: got %q, want %q", gotMsg, tc.wantMsg)
+			}
+			if gotStructured != tc.wantStructured {
+				t.Errorf("structured: got %v, want %v", gotStructured, tc.wantStructured)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Prepares `metahttp` for use cases where callers need to discriminate between HTTP error classes (400, 404, 409, 500) and produce user-friendly messages with context-aware suggestions. Two commits:

### 1. `feat(metahttp): return typed HTTPError for non-2xx responses`

- `Request` (and its `Get`/`Post`/`Put`/`Delete` helpers) now returns a typed `*metahttp.HTTPError` on non-2xx responses. The error wraps the status code, method, URL, raw body, and parsed error message.
- Callers can use `errors.As` to detect HTTP errors and discriminate between 400, 404, 409, 500, etc., to produce user-friendly messages and actionable suggestions.
- Parses the `{"error": "..."}` JSON body shape used by the backend APIs, with a fallback to the trimmed raw body when the shape does not match or the body is not JSON.
- Existing callers that just bubble the error up keep working unchanged — `*HTTPError` implements the `error` interface and its `Error()` string contains the status code, URL, and parsed server message.

### 2. `refactor(metahttp): log non-2xx at debug when body is structured`

The raw `"Request failed with status code ...: <body>"` Error-level log was originally useful when the returned error was opaque. Now that callers get a typed `*HTTPError`, surfacing the raw body at Error level duplicates the output for callers that produce a clean user-facing error from the typed error.

- `parseHTTPErrorMessage` now returns `(message, structured bool)`, where `structured == true` means the body parsed cleanly as the expected `{"error": "..."}` JSON shape.
- `Request` demotes the raw log to **Debug** level when the body is structured (caller can produce a clean user error, raw log would be noise), and keeps it at **Error** level when the body is opaque (unknown format, HTML from a proxy, plain text, legacy endpoints) so users still see diagnostic output even when the caller only emits a generic wrapper error.
- Fully backwards-compatible: any caller that still receives opaque error bodies continues to see the raw log line at Error level.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite passes)
- [x] `go mod tidy` (clean)
- [x] Unit tests in `pkg/metahttp/metahttp_test.go` cover: 2xx happy path, 400/404/409/500 error parsing, empty body, non-JSON body fallback (plain text, HTML from a proxy, non-standard JSON shape), `HTTPError.Error()` formatting, and the `parseHTTPErrorMessage` helper returning both the parsed message and the structured flag.