### PR TITLE
Remove game-admin requirement from debug admin-request

### DIFF
--- a/cmd/debug_admin_request.go
+++ b/cmd/debug_admin_request.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	clierrors "github.com/metaplay/cli/internal/errors"
-	"github.com/metaplay/cli/pkg/envapi"
 	"github.com/metaplay/cli/pkg/metahttp"
 	"github.com/metaplay/cli/pkg/styles"
 	"github.com/rs/zerolog/log"
@@ -155,17 +154,9 @@ func (o *debugAdminRequestOpts) Run(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Create TargetEnvironment.
-	targetEnv := envapi.NewTargetEnvironment(tokenSet, envConfig.StackDomain, envConfig.HumanID)
-
-	// Get environment details for admin API hostname
-	envDetails, err := targetEnv.GetDetails()
-	if err != nil {
-		return err
-	}
-
-	// Create a client for the game server admin API
-	adminAPIBaseURL := fmt.Sprintf("https://%s", envDetails.Deployment.AdminHostname)
+	// Admin hostname follows the infra-modules convention: <humanID>-admin.<stackDomain>.
+	// Avoids a privileged StackAPI /v0/deployments call just to learn the public hostname.
+	adminAPIBaseURL := fmt.Sprintf("https://%s-admin.%s", envConfig.HumanID, envConfig.StackDomain)
 	adminClient := metahttp.NewJSONClient(tokenSet, adminAPIBaseURL)
 
 	// Prepare request body if needed


### PR DESCRIPTION
## Summary

`metaplay debug admin-request` previously required game-admin permission on StackAPI because it fetched the full deployment record solely to learn the admin API hostname. The hostname is now constructed directly from the environment ID and stack domain (`<humanID>-admin.<stackDomain>`), matching the naming scheme used throughout the SDK, test fixtures, samples, and documentation.

Users who can reach the admin API itself can now use `debug admin-request` without additional StackAPI permissions. The command is also slightly faster, since it skips one HTTP round-trip per invocation.

## Test plan

Verified against `lovely-wombats-build-nimbly` on `p2-eu.metaplay.dev`:

- [x] `metaplay debug admin-request <env> GET api/hello` returns the expected `HelloResponse` JSON.
- [x] Debug log shows `Admin API: https://<humanID>-admin.<stackDomain>`.
- [x] POST with `--body` and `--file` send the request to the correct URL with `Content-Type: application/json` auto-detected.
- [x] Binary download mode (`-o <file>`) writes the response body to disk.