### PR TITLE
fix: disambiguate environment lookups by stack domain

### DIFF
--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -304,7 +304,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 		portalClient := portalapi.NewClient(targetEnv.TokenSet)
 
 		// Fetch info from the portal.
-		portalInfo, err := portalClient.FetchEnvironmentInfoByHumanID(envConfig.HumanID)
+		portalInfo, err := portalClient.FetchEnvironmentInfoByHumanID(envConfig.HumanID, envConfig.StackDomain)
 		if err != nil {
 			return err
 		}

--- a/cmd/get_environment_info.go
+++ b/cmd/get_environment_info.go
@@ -133,7 +133,7 @@ func (o *getEnvironmentInfoOpts) Run(cmd *cobra.Command) error {
 	if authProviderName == "metaplay" {
 		// Fetch information from the portal.
 		portalClient := portalapi.NewClient(tokenSet)
-		info, err := portalClient.FetchEnvironmentInfoByHumanID(envConfig.HumanID)
+		info, err := portalClient.FetchEnvironmentInfoByHumanID(envConfig.HumanID, envConfig.StackDomain)
 		if err != nil {
 			return err
 		}

--- a/cmd/get_server_info.go
+++ b/cmd/get_server_info.go
@@ -188,7 +188,7 @@ func (o *getServerInfoOpts) gatherDeployedServerInfo(ctx context.Context, target
 	var portalInfo *portalapi.EnvironmentInfo
 	if authProviderName == "metaplay" {
 		portalClient := portalapi.NewClient(targetEnv.TokenSet)
-		portalInfo, err = portalClient.FetchEnvironmentInfoByHumanID(envConfig.HumanID)
+		portalInfo, err = portalClient.FetchEnvironmentInfoByHumanID(envConfig.HumanID, envConfig.StackDomain)
 		if err != nil {
 			log.Debug().Err(err).Msg("Failed to fetch portal environment info")
 		}

--- a/cmd/project_util.go
+++ b/cmd/project_util.go
@@ -297,11 +297,40 @@ func resolveEnvironment(ctx context.Context, project *metaproj.MetaplayProject, 
 				WithSuggestion("If the name is a custom environment alias, the CLI must be invoked from the folder (or a subfolder) where metaplay-project.yaml is located. Otherwise, use the full environment ID (e.g., 'lovely-wombats-build-nimbly').")
 		}
 
-		// Try to resolve the environment from the portal by its human ID.
-		var err error
-		portalEnv, err = portalClient.FetchEnvironmentInfoByHumanID(environment)
+		// Resolve the environment from the portal by its human ID. The same human ID can
+		// legitimately exist on multiple stacks (self-hosted environments are unique per
+		// stack), and without a metaplay-project.yaml we have no stack domain to filter by,
+		// so disambiguate interactively when the portal returns more than one match.
+		environments, err := portalClient.FetchEnvironmentsByHumanID(environment, "")
 		if err != nil {
 			return nil, nil, err
+		}
+
+		switch len(environments) {
+		case 0:
+			return nil, nil, clierrors.Newf("Environment '%s' not found", environment).
+				WithSuggestion("Check available environments at https://portal.metaplay.dev")
+		case 1:
+			portalEnv = &environments[0]
+		default:
+			if !tui.IsInteractiveMode() {
+				return nil, nil, clierrors.Newf("Multiple environments match '%s'", environment).
+					WithDetails(fmt.Sprintf("Found %d environments across different stacks", len(environments))).
+					WithSuggestion("Run in interactive mode to choose, or invoke the CLI from a project directory whose metaplay-project.yaml pins the stack domain")
+			}
+
+			portalEnv, err = tui.ChooseFromListDialog[portalapi.EnvironmentInfo](
+				"Select Target Environment",
+				environments,
+				func(env *portalapi.EnvironmentInfo) (string, string) {
+					return env.Name, fmt.Sprintf("[%s on %s]", env.HumanID, env.StackDomain)
+				},
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			log.Info().Msgf(" %s %s %s", styles.RenderSuccess("✓"), portalEnv.Name, styles.RenderMuted(fmt.Sprintf("[%s on %s]", portalEnv.HumanID, portalEnv.StackDomain)))
 		}
 	}
 

--- a/pkg/portalapi/portalapi.go
+++ b/pkg/portalapi/portalapi.go
@@ -245,13 +245,32 @@ func (c *Client) FetchProjectEnvironments(projectUUID string) ([]EnvironmentInfo
 	return environmentInfos, nil
 }
 
-// FetchEnvironmentInfoByHumanID fetches information about an environment using its human ID.
-func (c *Client) FetchEnvironmentInfoByHumanID(humanID string) (*EnvironmentInfo, error) {
+// FetchEnvironmentsByHumanID fetches all environments visible to the caller that match the given
+// human ID, optionally narrowed to a specific stack domain. Self-hosted environments are only
+// unique by (project, stack domain), so the same human ID can legitimately exist on multiple
+// stacks; passing stackDomain narrows the result to a single row. When stackDomain is empty,
+// the portal applies no stack filter and the response may contain multiple matches.
+func (c *Client) FetchEnvironmentsByHumanID(humanID, stackDomain string) ([]EnvironmentInfo, error) {
 	url := fmt.Sprintf("/api/v1/environments?human_id=%s", humanID)
-	log.Debug().Msgf("Fetch environment by human ID from %s%s", c.httpClient.BaseURL, url)
+	if stackDomain != "" {
+		url += fmt.Sprintf("&stack_domain=%s", stackDomain)
+	}
+	log.Debug().Msgf("Fetch environments by human ID from %s%s", c.httpClient.BaseURL, url)
 	envInfos, err := metahttp.Get[[]EnvironmentInfo](c.httpClient, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch environment details from portal: %w", err)
+	}
+	return envInfos, nil
+}
+
+// FetchEnvironmentInfoByHumanID resolves a single environment by its human ID. When stackDomain
+// is provided, the lookup is unambiguous and at most one matching row exists. When stackDomain
+// is empty and the human ID resolves to more than one environment (possible for self-hosted
+// environments across stacks), the call fails with guidance to disambiguate.
+func (c *Client) FetchEnvironmentInfoByHumanID(humanID, stackDomain string) (*EnvironmentInfo, error) {
+	envInfos, err := c.FetchEnvironmentsByHumanID(humanID, stackDomain)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(envInfos) == 0 {
@@ -260,7 +279,13 @@ func (c *Client) FetchEnvironmentInfoByHumanID(humanID string) (*EnvironmentInfo
 	}
 
 	if len(envInfos) > 1 {
-		return nil, clierrors.Newf("Multiple environments match '%s'", humanID).
+		if stackDomain == "" {
+			return nil, clierrors.Newf("Multiple environments match '%s'", humanID).
+				WithDetails("This human ID exists on more than one stack — typically a self-hosted environment shared across stacks.").
+				WithSuggestion("Set 'stackDomain' for the environment in metaplay-project.yaml so the CLI can resolve it unambiguously")
+		}
+		// With stackDomain set, more than one row is a true invariant violation.
+		return nil, clierrors.Newf("Multiple environments match '%s' on stack '%s'", humanID, stackDomain).
 			WithSuggestion("Contact support — this is unexpected and may indicate a configuration issue")
 	}
 


### PR DESCRIPTION
## Summary

Environment human IDs are only globally unique for Metaplay-hosted environments; self-hosted environments are unique per (project, stack domain), so the same human ID can legitimately exist on multiple stacks. Commands that resolve an environment by human ID alone — `get environment-info`, `get server-info`, `deploy server` — currently error out for users with access to multiple matching stacks, with no actionable guidance:

```
% metaplay get environment-info stage
Error: Multiple environments match 'stage'
Hint: Contact support — this is unexpected and may indicate a configuration issue
```

This PR passes the configured `stackDomain` from `metaplay-project.yaml` alongside the human ID so the portal returns at most one row. When `stackDomain` is not yet known (no project yaml on disk — e.g. during initial environment resolution), the CLI fetches the full set of matches and prompts the user to pick interactively; non-interactive callers get a clear error directing them to a project context.

> Depends on portal support for the `stack_domain` query parameter on `GET /api/v1/environments`. Until that ships, new CLIs talking to old portals fall back to the existing multi-match error (no regression — the param is silently dropped by the older Zod schema).

## Changes

- **`pkg/portalapi/portalapi.go`** — split lookup into `FetchEnvironmentsByHumanID(humanID, stackDomain)` (list, optionally filtered) and `FetchEnvironmentInfoByHumanID(humanID, stackDomain)` (single-row helper). The multi-match error now points at stack-domain disambiguation rather than "contact support".
- **`cmd/get_environment_info.go`**, **`cmd/get_server_info.go`**, **`cmd/deploy_server.go`** — pass `envConfig.StackDomain` to the single-row helper. The `AuthProvider == "metaplay"` gate is preserved.
- **`cmd/project_util.go`** — in the no-project-yaml resolution path, list matches and, when multiple exist, surface the existing `tui.ChooseFromListDialog` with `[human_id on stack_domain]` so the user can pick. Non-interactive callers get an actionable error.

## Test plan

- [x] `go build ./...` — clean
- [x] `make test` — all packages pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l` on changed files — clean
- [x] `go mod tidy` — no go.mod/go.sum diff
- [x] Manual: against a portal account with access to two self-hosted envs sharing `human_id=stage` on different stack domains:
  - `metaplay get environment-info stage` from a project directory whose `metaplay-project.yaml` pins one of those stack domains → resolves to the matching row.
  - `metaplay get server-info` and `metaplay deploy server` → likewise resolve correctly.
  - Same `get environment-info stage` invoked from outside any project directory → interactive prompt with the candidate environments.
- [ ] Smoke: regression check on single-stack cases (globally-unique human IDs) — behavior unchanged.