### PR TITLE
Retry SDK downloads on transient stream failures

### DIFF
--- a/cmd/project_ops.go
+++ b/cmd/project_ops.go
@@ -202,7 +202,7 @@ func downloadSdkWithProgress(tokenSet *auth.TokenSet, sdkVersionInfo *portalapi.
 
 	err := tui.RunWithProgressBar(label, func(update func(current, total int64)) error {
 		var dlErr error
-		sdkZipPath, dlErr = portalClient.DownloadSdkByVersionIDWithProgress(tmpDir, sdkVersionInfo.ID, update)
+		sdkZipPath, dlErr = portalClient.DownloadSdkByVersionID(tmpDir, sdkVersionInfo.ID, update)
 		return dlErr
 	})
 	if err != nil {
@@ -224,7 +224,7 @@ func downloadAndExtractSdk(tokenSet *auth.TokenSet, targetProjectPath string, ve
 	var err error
 
 	// Download the specific version
-	sdkZipPath, err = portalClient.DownloadSdkByVersionID(tmpDir, versionInfo.ID)
+	sdkZipPath, err = portalClient.DownloadSdkByVersionID(tmpDir, versionInfo.ID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download SDK version '%s': %w", versionInfo.Version, err)
 	}

--- a/cmd/sdk_modification_check.go
+++ b/cmd/sdk_modification_check.go
@@ -460,7 +460,7 @@ func downloadSdkZipOnly(tokenSet *auth.TokenSet, versionID string) (string, erro
 	tmpDir := os.TempDir()
 	portalClient := portalapi.NewClient(tokenSet)
 
-	sdkZipPath, err := portalClient.DownloadSdkByVersionID(tmpDir, versionID)
+	sdkZipPath, err := portalClient.DownloadSdkByVersionID(tmpDir, versionID, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to download SDK: %w", err)
 	}

--- a/pkg/metahttp/metahttp.go
+++ b/pkg/metahttp/metahttp.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/metaplay/cli/internal/version"
@@ -89,27 +90,54 @@ func NewJSONClient(tokenSet *auth.TokenSet, baseURL string) *Client {
 	}
 }
 
-// Download a file from the specified URL to the specified file path.
-// Note: The file gets created even if the request fails.
-func Download(c *Client, url string, filePath string) (*resty.Response, error) {
-	// Perform the request: download directly to a file.
-	response, err := c.Resty.R().SetOutput(filePath).Get(url)
+// Download a file from the specified URL to the specified file path. If
+// onProgress is non-nil it is called periodically with the number of bytes
+// downloaded so far and the total size (0 if unknown).
+//
+// Retries transient failures (connection errors before the first byte, or
+// stream interruptions mid-body such as unexpected EOF) with exponential
+// backoff. Local I/O failures and HTTP error statuses are not retried.
+func Download(c *Client, url string, filePath string, onProgress func(downloaded, total int64)) (*resty.Response, error) {
+	const maxAttempts = 4
+	backoff := 1 * time.Second
 
-	if err != nil {
-		return nil, fmt.Errorf("Failed to download file from %s%s: %w", c.BaseURL, url, err)
+	var resp *resty.Response
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var streamErr error
+		resp, streamErr, lastErr = downloadOnce(c, url, filePath, onProgress)
+
+		// Non-retryable: success, HTTP error status, or local I/O failure.
+		if streamErr == nil {
+			return resp, lastErr
+		}
+
+		// Transient streaming/network error — retry unless we're out of attempts.
+		if attempt == maxAttempts {
+			return resp, fmt.Errorf("download from %s%s failed after %d attempts: %w", c.BaseURL, url, maxAttempts, streamErr)
+		}
+
+		log.Warn().Msgf("Download from %s%s interrupted (attempt %d/%d), retrying in %v: %v", c.BaseURL, url, attempt, maxAttempts, backoff, streamErr)
+		time.Sleep(backoff)
+		backoff *= 2
 	}
 
-	return response, nil
+	return resp, lastErr
 }
 
-// DownloadWithProgress downloads a file from the specified URL to the specified
-// file path, calling onProgress periodically with the number of bytes downloaded
-// and the total size (0 if unknown).
-func DownloadWithProgress(c *Client, url string, filePath string, onProgress func(downloaded, total int64)) (*resty.Response, error) {
+// downloadOnce performs a single download attempt. Returns
+// (resp, streamErr, terminalErr):
+//   - streamErr != nil indicates a transient network/streaming failure the
+//     caller should retry. resp may be nil.
+//   - terminalErr is the final error to return to the caller and is never
+//     retried (covers local I/O failures; nil on success and on HTTP error
+//     statuses, where the caller inspects resp.StatusCode()).
+func downloadOnce(c *Client, url string, filePath string, onProgress func(downloaded, total int64)) (*resty.Response, error, error) {
 	// Use SetDoNotParseResponse to get raw response body for streaming.
 	resp, err := c.Resty.R().SetDoNotParseResponse(true).Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to download file from %s%s: %w", c.BaseURL, url, err)
+		return nil, fmt.Errorf("failed to reach %s%s: %w", c.BaseURL, url, err), nil
 	}
 
 	rawBody := resp.RawBody()
@@ -118,13 +146,13 @@ func DownloadWithProgress(c *Client, url string, filePath string, onProgress fun
 	// On HTTP error, return the response without a Go error so the caller can
 	// inspect resp.StatusCode() and produce a domain-specific error message.
 	if resp.IsError() {
-		return resp, nil
+		return resp, nil, nil
 	}
 
-	// Create the output file.
+	// Create the output file (local error — not retryable).
 	outFile, err := os.Create(filePath)
 	if err != nil {
-		return resp, fmt.Errorf("Failed to create output file %s: %w", filePath, err)
+		return resp, nil, fmt.Errorf("Failed to create output file %s: %w", filePath, err)
 	}
 
 	// Determine total size from Content-Length header.
@@ -143,11 +171,12 @@ func DownloadWithProgress(c *Client, url string, filePath string, onProgress fun
 	_, copyErr := io.Copy(outFile, pr)
 	outFile.Close()
 	if copyErr != nil {
+		// Partial file is unusable; remove so the next attempt starts fresh.
 		os.Remove(filePath)
-		return resp, fmt.Errorf("Failed to write downloaded file %s: %w", filePath, copyErr)
+		return resp, fmt.Errorf("failed to write downloaded file %s: %w", filePath, copyErr), nil
 	}
 
-	return resp, nil
+	return resp, nil, nil
 }
 
 // progressReader wraps an io.Reader and reports progress via a callback.

--- a/pkg/portalapi/portalapi.go
+++ b/pkg/portalapi/portalapi.go
@@ -125,8 +125,10 @@ func (c *Client) AgreeToContract(contractID string) error {
 	return nil
 }
 
-// DownloadSdkByVersionID downloads the SDK with the specified version ID to the target directory.
-func (c *Client) DownloadSdkByVersionID(targetDir, versionID string) (string, error) {
+// DownloadSdkByVersionID downloads the SDK with the specified version ID to
+// the target directory. If onProgress is non-nil it is called periodically
+// with (bytesDownloaded, totalBytes).
+func (c *Client) DownloadSdkByVersionID(targetDir, versionID string, onProgress func(downloaded, total int64)) (string, error) {
 	if versionID == "" {
 		return "", fmt.Errorf("version ID is required")
 	}
@@ -135,38 +137,7 @@ func (c *Client) DownloadSdkByVersionID(targetDir, versionID string) (string, er
 	path := fmt.Sprintf("/api/v1/sdk/%s/download", versionID)
 	tmpFilename := fmt.Sprintf("metaplay-sdk-%08x.zip", rand.Uint32())
 	tmpSdkZipPath := filepath.Join(targetDir, tmpFilename)
-	resp, err := metahttp.Download(c.httpClient, path, tmpSdkZipPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to download SDK: %w", err)
-	}
-
-	// Handle server errors.
-	if resp.IsError() {
-		os.Remove(tmpSdkZipPath)
-		if resp.StatusCode() == 403 {
-			return "", clierrors.New("SDK download requires accepting the terms and conditions").
-				WithSuggestion("Visit https://portal.metaplay.dev to accept the SDK terms and conditions")
-		}
-		return "", clierrors.Newf("Failed to download the Metaplay SDK (status %d)", resp.StatusCode()).
-			WithSuggestion("Check your network connection and try again")
-	}
-
-	log.Debug().Msgf("Downloaded SDK to %s", tmpSdkZipPath)
-	return tmpSdkZipPath, nil
-}
-
-// DownloadSdkByVersionIDWithProgress downloads the SDK with progress reporting.
-// The onProgress callback receives (bytesDownloaded, totalBytes).
-func (c *Client) DownloadSdkByVersionIDWithProgress(targetDir, versionID string, onProgress func(downloaded, total int64)) (string, error) {
-	if versionID == "" {
-		return "", fmt.Errorf("version ID is required")
-	}
-
-	// Download the SDK to a temp file.
-	path := fmt.Sprintf("/api/v1/sdk/%s/download", versionID)
-	tmpFilename := fmt.Sprintf("metaplay-sdk-%08x.zip", rand.Uint32())
-	tmpSdkZipPath := filepath.Join(targetDir, tmpFilename)
-	resp, err := metahttp.DownloadWithProgress(c.httpClient, path, tmpSdkZipPath, onProgress)
+	resp, err := metahttp.Download(c.httpClient, path, tmpSdkZipPath, onProgress)
 	if err != nil {
 		return "", fmt.Errorf("failed to download SDK: %w", err)
 	}
@@ -440,5 +411,5 @@ func (c *Client) DownloadLatestSdk(targetDir string) (string, error) {
 	}
 
 	// Download the SDK
-	return c.DownloadSdkByVersionID(targetDir, latestSdk.ID)
+	return c.DownloadSdkByVersionID(targetDir, latestSdk.ID, nil)
 }


### PR DESCRIPTION
## Summary
- SDK downloads occasionally fail with `unexpected EOF` when the connection drops mid-body. The progress-aware path used `SetDoNotParseResponse`, which bypasses resty's retry middleware, so the streaming `io.Copy` error never reached the retry layer.
- Wrap the streaming download in an explicit retry loop (4 attempts, 1s/2s/4s backoff). Only transient network/stream errors retry; local I/O failures and HTTP error statuses are returned to the caller as before.
- Collapse the two parallel download functions. `metahttp` now exposes a single `Download` with an optional `onProgress` callback; `portalapi` exposes a single `DownloadSdkByVersionID`. Callers that don't need a progress bar pass `nil`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/metahttp/...`
- [ ] Manually exercise `metaplay init project` end-to-end (full SDK download with progress bar)
- [ ] Manually exercise `metaplay update sdk` (no-progress path)