### PR TITLE
Suppress error noise on Ctrl+C of dev commands (PLA-1205)

### DIFF
--- a/cmd/build_botclient.go
+++ b/cmd/build_botclient.go
@@ -55,6 +55,8 @@ func (o *buildBotClientOpts) Prepare(cmd *cobra.Command, args []string) error {
 }
 
 func (o *buildBotClientOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
 	// Load project config.
 	project, err := resolveProject()
 	if err != nil {
@@ -66,7 +68,7 @@ func (o *buildBotClientOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Check for .NET SDK installation and required version (based on SDK version).
-	if err := checkDotnetSdkVersion(project.VersionMetadata.MinDotnetSdkVersion); err != nil {
+	if err := checkDotnetSdkVersion(ctx, project.VersionMetadata.MinDotnetSdkVersion); err != nil {
 		return clierrors.Wrap(err, "Failed to verify .NET SDK version").
 			WithSuggestion("Install the required .NET SDK version")
 	}
@@ -75,7 +77,7 @@ func (o *buildBotClientOpts) Run(cmd *cobra.Command) error {
 	botClientPath := project.GetBotClientDir()
 
 	// Build the project
-	if err := execChildTask(botClientPath, "dotnet", []string{"build"}); err != nil {
+	if err := execChildTask(ctx, botClientPath, "dotnet", []string{"build"}); err != nil {
 		return clierrors.Wrap(err, "Failed to build BotClient .NET project").
 			WithSuggestion("Check the build output above for details")
 	}

--- a/cmd/build_dashboard.go
+++ b/cmd/build_dashboard.go
@@ -115,7 +115,8 @@ func (o *buildDashboardOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Check that required dashboard tools are installed and satisfy version requirements.
-	if err := checkDashboardToolVersions(project); err != nil {
+	ctx := cmd.Context()
+	if err := checkDashboardToolVersions(ctx, project); err != nil {
 		return err
 	}
 
@@ -128,7 +129,7 @@ func (o *buildDashboardOpts) Run(cmd *cobra.Command) error {
 		installArgs := []string{"install"}
 		log.Info().Msg("Install dashboard dependencies...")
 		log.Info().Msg(styles.RenderMuted(fmt.Sprintf("> pnpm %s", strings.Join(installArgs, " "))))
-		if err := execChildInteractive(dashboardPath, "pnpm", installArgs, nil); err != nil {
+		if err := execChildInteractive(ctx, dashboardPath, "pnpm", installArgs, nil); err != nil {
 			return clierrors.Wrap(err, "Failed to install LiveOps Dashboard dependencies").
 				WithSuggestion("Try running 'metaplay dev clean-dashboard-artifacts' to remove build artifacts, then retry")
 		}
@@ -146,7 +147,7 @@ func (o *buildDashboardOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 	log.Info().Msg("Build dashboard...")
 	log.Info().Msg(styles.RenderMuted(fmt.Sprintf("> pnpm %s", strings.Join(buildArgs, " "))))
-	err = execChildInteractive(dashboardPath, "pnpm", buildArgs, nil)
+	err = execChildInteractive(ctx, dashboardPath, "pnpm", buildArgs, nil)
 	if err != nil {
 		return clierrors.Wrap(err, "Failed to build the LiveOps Dashboard").
 			WithSuggestion("Check the output above for details")

--- a/cmd/build_image.go
+++ b/cmd/build_image.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -111,6 +112,7 @@ func (o *buildImageOpts) Prepare(cmd *cobra.Command, args []string) error {
 }
 
 func (o *buildImageOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
 	log.Info().Msg("")
 	log.Info().Msg(styles.RenderTitle("Build Docker Image"))
 	log.Info().Msg("")
@@ -181,13 +183,13 @@ func (o *buildImageOpts) Run(cmd *cobra.Command) error {
 
 	// Check that docker is installed and running
 	log.Debug().Msgf("Check that docker is available")
-	err = checkDockerAvailable()
+	err = checkDockerAvailable(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Check Docker version: warn if using old versions
-	dockerVersionInfo, dockerUpgradeRecommended, err := checkDockerVersion()
+	dockerVersionInfo, dockerUpgradeRecommended, err := checkDockerVersion(ctx)
 	if err != nil {
 		log.Warn().Msgf("Warning: Failed to check Docker version: %v", err)
 	}
@@ -205,7 +207,7 @@ func (o *buildImageOpts) Run(cmd *cobra.Command) error {
 	}
 
 	// Check that the build engine is available.
-	err = checkBuildEngineAvailable(buildEngine)
+	err = checkBuildEngineAvailable(ctx, buildEngine)
 	if err != nil {
 		return err
 	}
@@ -269,7 +271,7 @@ func (o *buildImageOpts) Run(cmd *cobra.Command) error {
 		extraArgs:   o.extraArgs,
 	}
 
-	if err := buildDockerImage(buildParams); err != nil {
+	if err := buildDockerImage(ctx, buildParams); err != nil {
 		return err
 	}
 
@@ -310,11 +312,17 @@ func resolveBuildEngine(engine string) (string, error) {
 	return "", fmt.Errorf("invalid Docker build engine '%s', must be one of: %v", engine, validBuildEngines)
 }
 
-func checkCommand(command string, args ...string) error {
-	cmd := exec.Command(command, args...)
+func checkCommand(ctx context.Context, command string, args ...string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, command, args...)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		trimmed := strings.TrimSpace(stderr.String())
 		if trimmed != "" {
 			return fmt.Errorf("%v: %s", err, truncateForLog(trimmed, 500))
@@ -325,13 +333,20 @@ func checkCommand(command string, args ...string) error {
 }
 
 // executeCommand runs a command with the given arguments in the specified working directory.
-func executeCommand(workingDir string, env []string, command string, args ...string) error {
-	cmd := exec.Command(command, args...)
+func executeCommand(ctx context.Context, workingDir string, env []string, command string, args ...string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = workingDir
-	return cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	defer killOnExit(cmd)()
+	return cmd.Wait()
 }
 
 // rebasePath calculates a new path for `targetPath` such that it is relative
@@ -362,7 +377,11 @@ func rebasePath(targetPath, newBaseDir string) (string, error) {
 // Check if docker is available and running. Uses a short timeout as 'docker' invocation
 // can sometimes hang indefinitely. In CI environments, uses a longer timeout to account
 // for slower daemon startup.
-func checkDockerAvailable() error {
+func checkDockerAvailable(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Use a longer timeout in CI where Docker daemon startup can be slower.
 	// GitHub Actions in particular is known to have long Docker init latencies.
 	timeout := 10 * time.Second
@@ -374,7 +393,7 @@ func checkDockerAvailable() error {
 	// indefinitely in some cases).
 	done := make(chan error)
 	go func() {
-		done <- checkCommand("docker", "info")
+		done <- checkCommand(ctx, "docker", "info")
 	}()
 
 	// Wait for docker to respond, printing a waiting message after 1sec.
@@ -385,6 +404,8 @@ func checkDockerAvailable() error {
 				WithSuggestion("Make sure Docker Desktop is running, or start the docker daemon")
 		}
 		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-time.After(time.Second):
 		log.Info().Msgf("Waiting for docker daemon to respond...")
 	}
@@ -402,6 +423,8 @@ func checkDockerAvailable() error {
 					WithSuggestion("Make sure Docker Desktop is running, or start the docker daemon")
 			}
 			return nil
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-tick.C:
 			log.Info().Msgf("Still waiting for docker daemon to respond...")
 		case <-deadline:
@@ -412,12 +435,12 @@ func checkDockerAvailable() error {
 }
 
 // Check that the specified docker build engine is available.
-func checkBuildEngineAvailable(buildEngine string) error {
+func checkBuildEngineAvailable(ctx context.Context, buildEngine string) error {
 	log.Debug().Msgf("Check that build engine %s is available", buildEngine)
 
 	switch buildEngine {
 	case "buildx":
-		err := checkCommand("docker", "buildx", "version")
+		err := checkCommand(ctx, "docker", "buildx", "version")
 		if err != nil {
 			return clierrors.Wrap(err, "Docker buildx is not available").
 				WithSuggestion("Install Docker buildx or use --engine=buildkit instead")
@@ -463,16 +486,22 @@ func truncateForLog(s string, n int) string {
 }
 
 // Check Docker version and return parsed server version
-func checkDockerVersion() (*dockerVersionInfo, bool, error) {
+func checkDockerVersion(ctx context.Context) (*dockerVersionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
 	// Get Docker version in JSON format to access server version
 	// Use the explicit Go template syntax instead of the `json` shorthand —
 	// the shorthand was added in Docker CLI 22.06 and older clients render
 	// it as the literal string "json".
-	cmd := exec.Command("docker", "version", "--format", "{{json .}}")
+	cmd := exec.CommandContext(ctx, "docker", "version", "--format", "{{json .}}")
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, false, ctxErr
+		}
 		log.Debug().Err(err).Str("stderr", stderr.String()).Msgf("'docker version --format json' failed")
 		return nil, false, fmt.Errorf("failed to get Docker version: %w", err)
 	}
@@ -513,7 +542,7 @@ type buildDockerImageParams struct {
 }
 
 // buildDockerImage builds a Docker image with the given parameters.
-func buildDockerImage(params buildDockerImageParams) error {
+func buildDockerImage(ctx context.Context, params buildDockerImageParams) error {
 	// Resolve docker build root directory. All other paths need to be made relative to it.
 	buildRootDir := params.project.GetBuildRootDir()
 
@@ -623,7 +652,7 @@ func buildDockerImage(params buildDockerImageParams) error {
 	log.Info().Msg("")
 
 	// Execute the docker build
-	if err := executeCommand(buildRootDir, dockerEnv, "docker", dockerArgs...); err != nil {
+	if err := executeCommand(ctx, buildRootDir, dockerEnv, "docker", dockerArgs...); err != nil {
 		printBitbucketRequirementsBanner()
 		return clierrors.Wrap(err, "Docker build failed").
 			WithSuggestion("Check the build output above for details")

--- a/cmd/build_server.go
+++ b/cmd/build_server.go
@@ -49,6 +49,8 @@ func (o *buildServerOpts) Prepare(cmd *cobra.Command, args []string) error {
 }
 
 func (o *buildServerOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
 	// Load project config.
 	project, err := resolveProject()
 	if err != nil {
@@ -60,7 +62,7 @@ func (o *buildServerOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Check for .NET SDK installation and required version (based on SDK version).
-	if err := checkDotnetSdkVersion(project.VersionMetadata.MinDotnetSdkVersion); err != nil {
+	if err := checkDotnetSdkVersion(ctx, project.VersionMetadata.MinDotnetSdkVersion); err != nil {
 		return err
 	}
 
@@ -68,7 +70,7 @@ func (o *buildServerOpts) Run(cmd *cobra.Command) error {
 	serverPath := project.GetServerDir()
 
 	// Build the project.
-	if err := execChildTask(serverPath, "dotnet", []string{"build"}); err != nil {
+	if err := execChildTask(ctx, serverPath, "dotnet", []string{"build"}); err != nil {
 		return clierrors.Wrap(err, "Failed to build game server .NET project").
 			WithSuggestion("Check the build output above for details")
 	}

--- a/cmd/dashboard_helper.go
+++ b/cmd/dashboard_helper.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -20,14 +21,21 @@ import (
 )
 
 // Checks if Node.js is installed and verifies the version
-func checkNodeVersion(recommendedVersion *version.Version) error {
+func checkNodeVersion(ctx context.Context, recommendedVersion *version.Version) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Run the 'node --version' command
-	cmd := exec.Command("node", "--version")
+	cmd := exec.CommandContext(ctx, "node", "--version")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 
 	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return errors.New("Node.js is not installed or not in PATH. Please install Node.js from: https://nodejs.org/")
 	}
 
@@ -64,13 +72,20 @@ func checkNodeVersion(recommendedVersion *version.Version) error {
 }
 
 // Checks if pnpm is installed and verifies the version
-func checkPnpmVersion(recommendedVersion *version.Version) error {
+func checkPnpmVersion(ctx context.Context, recommendedVersion *version.Version) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Run the 'pnpm --version' command
-	cmd := exec.Command("pnpm", "--version")
+	cmd := exec.CommandContext(ctx, "pnpm", "--version")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return errors.New("pnpm is not installed or not in PATH. Please install pnpm: https://pnpm.io/installation")
 	}
 
@@ -108,14 +123,14 @@ func checkPnpmVersion(recommendedVersion *version.Version) error {
 	return nil
 }
 
-func checkDashboardToolVersions(project *metaproj.MetaplayProject) error {
+func checkDashboardToolVersions(ctx context.Context, project *metaproj.MetaplayProject) error {
 	// Check for Node installation and minimum required version.
-	if err := checkNodeVersion(project.VersionMetadata.RecommendedNodeVersion); err != nil {
+	if err := checkNodeVersion(ctx, project.VersionMetadata.RecommendedNodeVersion); err != nil {
 		return err
 	}
 
 	// Check for pnpm installation and minimum required version.
-	if err := checkPnpmVersion(project.VersionMetadata.RecommendedPnpmVersion); err != nil {
+	if err := checkPnpmVersion(ctx, project.VersionMetadata.RecommendedPnpmVersion); err != nil {
 		return err
 	}
 

--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -133,7 +133,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 
 	// Check that docker is installed and running
 	log.Debug().Msgf("Check if docker is available")
-	err = checkDockerAvailable()
+	err = checkDockerAvailable(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/cmd/dev_botclient.go
+++ b/cmd/dev_botclient.go
@@ -108,9 +108,10 @@ func (o *devBotClientOpts) Run(cmd *cobra.Command) error {
 
 	// Resolve botclient path.
 	botClientPath := project.GetBotClientDir()
+	ctx := cmd.Context()
 
 	// Build the BotClient project
-	if err := execChildInteractive(botClientPath, "dotnet", []string{"build"}, commonDotnetEnvVars); err != nil {
+	if err := execChildInteractive(ctx, botClientPath, "dotnet", []string{"build"}, commonDotnetEnvVars); err != nil {
 		return clierrors.Wrap(err, "Failed to build the BotClient .NET project").
 			WithSuggestion("Check the build output for errors")
 	}
@@ -118,7 +119,7 @@ func (o *devBotClientOpts) Run(cmd *cobra.Command) error {
 	// Run the project without rebuilding
 	botRunFlags := append([]string{"run", "--no-build"}, targetEnvFlags...)
 	botRunFlags = append(botRunFlags, o.extraArgs...)
-	if err := execChildInteractive(botClientPath, "dotnet", botRunFlags, commonDotnetEnvVars); err != nil {
+	if err := execChildInteractive(ctx, botClientPath, "dotnet", botRunFlags, commonDotnetEnvVars); err != nil {
 		return clierrors.Wrap(err, "BotClient exited with error")
 	}
 

--- a/cmd/dev_botclient.go
+++ b/cmd/dev_botclient.go
@@ -101,14 +101,15 @@ func (o *devBotClientOpts) Run(cmd *cobra.Command) error {
 		log.Debug().Msgf("Flags to run against environment %s: %v", o.flagEnvironment, targetEnvFlags)
 	}
 
+	ctx := cmd.Context()
+
 	// Check for .NET SDK installation and required version (based on SDK version).
-	if err := checkDotnetSdkVersion(project.VersionMetadata.MinDotnetSdkVersion); err != nil {
+	if err := checkDotnetSdkVersion(ctx, project.VersionMetadata.MinDotnetSdkVersion); err != nil {
 		return err
 	}
 
 	// Resolve botclient path.
 	botClientPath := project.GetBotClientDir()
-	ctx := cmd.Context()
 
 	// Build the BotClient project
 	if err := execChildInteractive(ctx, botClientPath, "dotnet", []string{"build"}, commonDotnetEnvVars); err != nil {

--- a/cmd/dev_dashboard.go
+++ b/cmd/dev_dashboard.go
@@ -54,7 +54,8 @@ func (o *devDashboardOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Check that required dashboard tools are installed and satisfy version requirements.
-	if err := checkDashboardToolVersions(project); err != nil {
+	ctx := cmd.Context()
+	if err := checkDashboardToolVersions(ctx, project); err != nil {
 		return err
 	}
 
@@ -62,14 +63,14 @@ func (o *devDashboardOpts) Run(cmd *cobra.Command) error {
 	dashboardPath := project.GetDashboardDir()
 
 	// Install dashboard dependencies
-	if err := execChildInteractive(dashboardPath, "pnpm", []string{"install"}, nil); err != nil {
+	if err := execChildInteractive(ctx, dashboardPath, "pnpm", []string{"install"}, nil); err != nil {
 		return clierrors.Wrap(err, "Failed to install dashboard dependencies").
 			WithSuggestion("Try `metaplay dev clean-dashboard-artifacts` to remove stale build artifacts before reinstalling.")
 	}
 
 	// Run the dashboard project in dev mode
 	devArgs := append([]string{"dev"}, o.extraArgs...)
-	if err := execChildInteractive(dashboardPath, "pnpm", devArgs, nil); err != nil {
+	if err := execChildInteractive(ctx, dashboardPath, "pnpm", devArgs, nil); err != nil {
 		return clierrors.Wrap(err, "Failed to run the LiveOps Dashboard").
 			WithSuggestion("Try `metaplay dev clean-dashboard-artifacts` to remove stale build artifacts before reinstalling.")
 	}

--- a/cmd/dev_dashboard.go
+++ b/cmd/dev_dashboard.go
@@ -5,8 +5,7 @@
 package cmd
 
 import (
-	"fmt"
-
+	clierrors "github.com/metaplay/cli/internal/errors"
 	"github.com/metaplay/cli/pkg/styles"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -47,7 +46,7 @@ func (o *devDashboardOpts) Run(cmd *cobra.Command) error {
 
 	// Check that project uses a custom dashboard, otherwise error out
 	if !project.UsesCustomDashboard() {
-		return fmt.Errorf("project does not have a custom dashboard to run")
+		return clierrors.New("Project does not have a custom dashboard to run")
 	}
 
 	log.Info().Msg("")
@@ -64,15 +63,15 @@ func (o *devDashboardOpts) Run(cmd *cobra.Command) error {
 
 	// Install dashboard dependencies
 	if err := execChildInteractive(dashboardPath, "pnpm", []string{"install"}, nil); err != nil {
-		log.Info().Msg("Have you tried running `metaplay dev clean-dashboard-artifacts`? This removes build artifacts before installing dependencies, potentially fixing some problems.")
-		return fmt.Errorf("failed to install dashboard dependencies: %s", err)
+		return clierrors.Wrap(err, "Failed to install dashboard dependencies").
+			WithSuggestion("Try `metaplay dev clean-dashboard-artifacts` to remove stale build artifacts before reinstalling.")
 	}
 
 	// Run the dashboard project in dev mode
 	devArgs := append([]string{"dev"}, o.extraArgs...)
 	if err := execChildInteractive(dashboardPath, "pnpm", devArgs, nil); err != nil {
-		log.Info().Msg("Have you tried running `metaplay dev clean-dashboard-artifacts`? This removes build artifacts before installing dependencies, potentially fixing some problems.")
-		return fmt.Errorf("failed to run the LiveOps Dashboard: %s", err)
+		return clierrors.Wrap(err, "Failed to run the LiveOps Dashboard").
+			WithSuggestion("Try `metaplay dev clean-dashboard-artifacts` to remove stale build artifacts before reinstalling.")
 	}
 
 	// The dashboard terminated normally

--- a/cmd/dev_image.go
+++ b/cmd/dev_image.go
@@ -60,6 +60,8 @@ func (o *devImageOpts) Prepare(cmd *cobra.Command, args []string) error {
 }
 
 func (o *devImageOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
 	// Try to resolve the project & auth provider.
 	project, err := resolveProject()
 	if err != nil {
@@ -67,7 +69,7 @@ func (o *devImageOpts) Run(cmd *cobra.Command) error {
 	}
 
 	// Check that docker is installed and running
-	if err := checkCommand("docker", "info"); err != nil {
+	if err := checkCommand(ctx, "docker", "info"); err != nil {
 		return clierrors.New("Failed to invoke Docker").
 			WithSuggestion("Ensure Docker Desktop is installed and running")
 	}
@@ -123,7 +125,7 @@ func (o *devImageOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Run the docker image.
-	if err := executeCommand(".", nil, "docker", dockerRunArgs...); err != nil {
+	if err := executeCommand(ctx, ".", nil, "docker", dockerRunArgs...); err != nil {
 		return clierrors.Wrap(err, "Docker run failed")
 	}
 

--- a/cmd/dev_server.go
+++ b/cmd/dev_server.go
@@ -77,14 +77,15 @@ func (o *devServerOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg(styles.RenderTitle("Run Game Server Locally"))
 	log.Info().Msg("")
 
+	ctx := cmd.Context()
+
 	// Check for .NET SDK installation and required version (based on SDK version).
-	if err := checkDotnetSdkVersion(project.VersionMetadata.MinDotnetSdkVersion); err != nil {
+	if err := checkDotnetSdkVersion(ctx, project.VersionMetadata.MinDotnetSdkVersion); err != nil {
 		return err
 	}
 
 	// Resolve server path.
 	serverPath := project.GetServerDir()
-	ctx := cmd.Context()
 
 	if o.flagWatch {
 		// Run with file watching (auto-restart on code changes).

--- a/cmd/dev_server.go
+++ b/cmd/dev_server.go
@@ -84,22 +84,23 @@ func (o *devServerOpts) Run(cmd *cobra.Command) error {
 
 	// Resolve server path.
 	serverPath := project.GetServerDir()
+	ctx := cmd.Context()
 
 	if o.flagWatch {
 		// Run with file watching (auto-restart on code changes).
 		watchArgs := append([]string{"watch", "run", "--no-hot-reload", "/p:Configuration=Watch"}, o.extraArgs...)
-		if err := execChildInteractive(serverPath, "dotnet", watchArgs, commonDotnetEnvVars); err != nil {
+		if err := execChildInteractive(ctx, serverPath, "dotnet", watchArgs, commonDotnetEnvVars); err != nil {
 			return fmt.Errorf("game server exited with error: %s", err)
 		}
 	} else {
 		// Build the game server .NET project.
-		if err := execChildInteractive(serverPath, "dotnet", []string{"build"}, commonDotnetEnvVars); err != nil {
+		if err := execChildInteractive(ctx, serverPath, "dotnet", []string{"build"}, commonDotnetEnvVars); err != nil {
 			return fmt.Errorf("failed to build the game server .NET project: %s", err)
 		}
 
 		// Run the game server (skip build).
 		runArgs := append([]string{"run", "--no-build"}, o.extraArgs...)
-		if err := execChildInteractive(serverPath, "dotnet", runArgs, commonDotnetEnvVars); err != nil {
+		if err := execChildInteractive(ctx, serverPath, "dotnet", runArgs, commonDotnetEnvVars); err != nil {
 			return fmt.Errorf("game server exited with error: %s", err)
 		}
 	}

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -121,9 +122,18 @@ func execChildTask(workingDir string, binary string, args []string) error {
 // Runs a child process in "interactive" mode where all inputs/outputs are forwarded
 // to the sub-process. If extraEnv is specified, its contents are appended to the current
 // environment variables.
-func execChildInteractive(workingDir string, binary string, args []string, extraEnv []string) error {
+//
+// If ctx is already canceled, returns ctx.Err() without spawning anything — this
+// matters when a previous Ctrl+C canceled the root context: we don't want to
+// start the next pipeline step (e.g. `pnpm install` after a Ctrl+C during the
+// preceding version check).
+func execChildInteractive(ctx context.Context, workingDir string, binary string, args []string, extraEnv []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Create the command to run the .NET binary
-	cmd := exec.Command(binary, args...)
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = workingDir
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -165,6 +165,11 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 		return fmt.Errorf("failed to start the binary: %w", err)
 	}
 
+	// On Windows, attach the child to a Job Object so the entire process
+	// tree dies together when we exit. Without this, pnpm/npm .cmd shims
+	// leave node descendants alive on Ctrl+C. No-op on other platforms.
+	defer killOnExit(cmd)()
+
 	// Goroutine to forward signals to the subprocess. Exits when signalChan is closed.
 	go func() {
 		for sig := range signalChan {

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -73,13 +73,20 @@ Visit: https://dotnet.microsoft.com/download for instructions specific to your o
 
 // Checks if .NET SDK is installed and check that it is recent enough for the SDK
 // version used.
-func checkDotnetSdkVersion(requiredDotnetVersion *version.Version) error {
+func checkDotnetSdkVersion(ctx context.Context, requiredDotnetVersion *version.Version) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Note: This gets the SDK version, not runtime version (eg, 8.0.400)
-	cmd := exec.Command("dotnet", "--version")
+	cmd := exec.CommandContext(ctx, "dotnet", "--version")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return clierrors.New(".NET SDK is not installed or not in PATH").
 			WithSuggestion(getDotnetInstallInstructions())
 	}
@@ -105,14 +112,22 @@ func checkDotnetSdkVersion(requiredDotnetVersion *version.Version) error {
 	return nil
 }
 
-func execChildTask(workingDir string, binary string, args []string) error {
-	cmd := exec.Command(binary, args...)
+func execChildTask(ctx context.Context, workingDir string, binary string, args []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = workingDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	log.Info().Msg(styles.RenderMuted(fmt.Sprintf("%s$ %s %s", workingDir, binary, strings.Join(args, " "))))
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start the binary: %w", err)
+	}
+	defer killOnExit(cmd)()
+	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf("failed to build the project: %w", err)
 	}
 

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/hashicorp/go-version"
@@ -19,6 +20,18 @@ import (
 	"github.com/metaplay/cli/pkg/styles"
 	"github.com/rs/zerolog/log"
 )
+
+// SignaledError indicates a child process exited after a forwarded
+// SIGINT/SIGTERM (or was killed by an uncaught signal). It renders
+// identically to the underlying error — callers that want to tolerate
+// Ctrl+C detect it with errors.As.
+type SignaledError struct {
+	Signal os.Signal
+	Err    error
+}
+
+func (e *SignaledError) Error() string { return e.Err.Error() }
+func (e *SignaledError) Unwrap() error { return e.Err }
 
 // Environment variables to pass to all dotnet commands.
 var commonDotnetEnvVars = []string{
@@ -121,18 +134,33 @@ func execChildInteractive(workingDir string, binary string, args []string, extra
 		cmd.Env = append(os.Environ(), extraEnv...)
 	}
 
-	// Create a channel to forward signals to the subprocess
+	// Create a channel to forward signals to the subprocess. Track whether we
+	// forwarded one so we can mark the resulting error as signal-induced; this
+	// works on Windows too (where ExitCode() != -1 for Ctrl+C).
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+
+	var (
+		mu           sync.Mutex
+		forwardedSig os.Signal
+	)
+
+	defer func() {
+		signal.Stop(signalChan)
+		close(signalChan)
+	}()
 
 	// Start the process
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start the binary: %w", err)
 	}
 
-	// Goroutine to forward signals to the subprocess
+	// Goroutine to forward signals to the subprocess. Exits when signalChan is closed.
 	go func() {
 		for sig := range signalChan {
+			mu.Lock()
+			forwardedSig = sig
+			mu.Unlock()
 			if cmd.Process != nil {
 				_ = cmd.Process.Signal(sig)
 			}
@@ -140,12 +168,27 @@ func execChildInteractive(workingDir string, binary string, args []string, extra
 	}()
 
 	// Wait for the subprocess to complete
-	if err := cmd.Wait(); err != nil {
-		// If the process was terminated by a signal, exit cleanly
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
-			return fmt.Errorf("binary exited with error: %w", err)
-		}
+	err := cmd.Wait()
+	if err == nil {
+		return nil
 	}
 
-	return nil
+	wrapped := fmt.Errorf("binary exited with error: %w", err)
+
+	mu.Lock()
+	sig := forwardedSig
+	mu.Unlock()
+
+	// On Unix, ExitCode() == -1 indicates the child was killed by a signal.
+	// On Windows, that signal won't be observable that way, so we also fall
+	// back to whether we forwarded one ourselves.
+	killedBySignal := sig != nil
+	if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
+		killedBySignal = true
+	}
+
+	if killedBySignal {
+		return &SignaledError{Signal: sig, Err: wrapped}
+	}
+	return wrapped
 }

--- a/cmd/init_dashboard.go
+++ b/cmd/init_dashboard.go
@@ -96,7 +96,8 @@ func (o *initDashboardOpts) Run(cmd *cobra.Command) error {
 	}
 
 	// Check that required dashboard tools are installed and satisfy version requirements.
-	if err := checkDashboardToolVersions(project); err != nil {
+	ctx := cmd.Context()
+	if err := checkDashboardToolVersions(ctx, project); err != nil {
 		return err
 	}
 
@@ -164,7 +165,7 @@ func (o *initDashboardOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 	log.Info().Msgf("Running %s to install dashboard dependencies...", styles.RenderTechnical("pnpm install"))
 	pathToDashboardDir := filepath.Join(project.RelativeDir, dashboardDirRelative)
-	if err := execChildInteractive(pathToDashboardDir, "pnpm", []string{"install"}, nil); err != nil {
+	if err := execChildInteractive(ctx, pathToDashboardDir, "pnpm", []string{"install"}, nil); err != nil {
 		return clierrors.Wrap(err, "Failed to run 'pnpm install'").
 			WithSuggestion("Check that pnpm is installed and try running 'pnpm install' manually")
 	}

--- a/cmd/process_tree_other.go
+++ b/cmd/process_tree_other.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+//go:build !windows
+
+package cmd
+
+import "os/exec"
+
+// killOnExit is a no-op on Unix: process groups + SIGTERM/SIGKILL already
+// handle descendant cleanup naturally. The Windows variant attaches the
+// child to a Job Object so killing the parent atomically tears down the
+// whole subprocess tree.
+func killOnExit(_ *exec.Cmd) func() {
+	return func() {}
+}

--- a/cmd/process_tree_windows.go
+++ b/cmd/process_tree_windows.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"unsafe"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
+)
+
+// killOnExit attaches cmd.Process to a Windows Job Object configured with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, then returns a cleanup func. When the
+// cleanup func runs (or the parent process dies for any reason and the
+// handle is released), the kernel terminates every process in the job —
+// the child and all of its descendants — atomically.
+//
+// This matters on Windows because tools like pnpm/npm are installed as
+// .cmd shims: `exec.Command("pnpm", ...)` actually launches cmd.exe to
+// run pnpm.cmd, which spawns node.exe, which spawns its own worker
+// processes. CTRL_C_EVENT propagation across that chain is unreliable —
+// the immediate cmd.exe may catch the signal and prompt "Terminate batch
+// job (Y/N)?" while the node descendants stay alive as orphans. With the
+// job object, killing the parent reliably tears down the whole tree.
+//
+// Must be called after cmd.Start(). On failure, returns a no-op cleanup
+// and logs at debug — the caller continues without job protection.
+func killOnExit(cmd *exec.Cmd) func() {
+	if cmd.Process == nil {
+		return func() {}
+	}
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		log.Debug().Err(err).Msg("CreateJobObject failed; subprocess tree may outlive cancellation")
+		return func() {}
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		log.Debug().Err(err).Msg("SetInformationJobObject failed; subprocess tree may outlive cancellation")
+		return func() {}
+	}
+
+	// AssignProcessToJobObject needs PROCESS_TERMINATE | PROCESS_SET_QUOTA
+	// on the target handle. Go's os.Process keeps its own handle but doesn't
+	// expose it, so we open a fresh one by PID.
+	proc, err := windows.OpenProcess(
+		windows.PROCESS_TERMINATE|windows.PROCESS_SET_QUOTA,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		log.Debug().Err(err).Msg("OpenProcess failed; subprocess tree may outlive cancellation")
+		return func() {}
+	}
+	defer windows.CloseHandle(proc)
+
+	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
+		_ = windows.CloseHandle(job)
+		log.Debug().Err(err).Msg(fmt.Sprintf("AssignProcessToJobObject failed for pid %d; subprocess tree may outlive cancellation", cmd.Process.Pid))
+		return func() {}
+	}
+
+	return func() { _ = windows.CloseHandle(job) }
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -361,6 +362,14 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		// Run the command.
 		err = opts.Run(cmd)
 		if err != nil {
+			// A child process killed by a forwarded Ctrl+C (or SIGTERM) is a
+			// deliberate interrupt, not a failure. Exit silently with the
+			// POSIX SIGINT convention (128 + 2) without printing misleading
+			// error guidance.
+			var sigErr *SignaledError
+			if errors.As(err, &sigErr) {
+				os.Exit(130)
+			}
 			// Only show usage for explicit usage errors from Run()
 			if clierrors.IsUsageError(err) {
 				stderrLogger.Info().Msgf("%s", cmd.UsageString())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -349,6 +349,9 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		// Prepare the command.
 		err := opts.Prepare(cmd, args)
 		if err != nil {
+			if wasInterrupted(cmd, err) {
+				os.Exit(130)
+			}
 			// Show usage help for Prepare errors that are either explicit usage errors
 			// or plain Go errors (which are assumed to be usage errors since Prepare
 			// validates arguments). CLIErrors with ExitRuntime skip usage text.
@@ -362,12 +365,7 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		// Run the command.
 		err = opts.Run(cmd)
 		if err != nil {
-			// A child process killed by a forwarded Ctrl+C (or SIGTERM) is a
-			// deliberate interrupt, not a failure. Exit silently with the
-			// POSIX SIGINT convention (128 + 2) without printing misleading
-			// error guidance.
-			var sigErr *SignaledError
-			if errors.As(err, &sigErr) {
+			if wasInterrupted(cmd, err) {
 				os.Exit(130)
 			}
 			// Only show usage for explicit usage errors from Run()
@@ -378,6 +376,31 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 			os.Exit(clierrors.GetExitCode(err))
 		}
 	}
+}
+
+// wasInterrupted reports whether the error is a side-effect of the user
+// interrupting the CLI (Ctrl+C / SIGTERM). When true, callers should exit
+// silently with the POSIX SIGINT convention (128 + 2) rather than printing
+// the error — a signal-killed child can otherwise surface as a misleading
+// message (e.g. `exec.Command("pnpm", "--version").Run()` failing during
+// interrupt looks identical to "pnpm not installed").
+//
+// We check three signals in order of specificity:
+//  1. the root context was canceled via SIGINT/SIGTERM (matches signal.NotifyContext);
+//  2. the error chain itself carries context.Canceled (e.g. an interactive prompt);
+//  3. a SignaledError from execChildInteractive (defensive — covers the case
+//     where a forwarded signal killed the child but didn't reach our context).
+func wasInterrupted(cmd *cobra.Command, err error) bool {
+	if errors.Is(cmd.Context().Err(), context.Canceled) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if _, ok := errors.AsType[*SignaledError](err); ok {
+		return true
+	}
+	return false
 }
 
 // isCLIError checks if the error is a CLIError type.

--- a/cmd/test_dotnet_unit.go
+++ b/cmd/test_dotnet_unit.go
@@ -54,6 +54,8 @@ func init() {
 func (o *testDotnetUnitOpts) Prepare(cmd *cobra.Command, args []string) error { return nil }
 
 func (o *testDotnetUnitOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
 	// Resolve project
 	project, err := resolveProject()
 	if err != nil {
@@ -65,7 +67,7 @@ func (o *testDotnetUnitOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Check for .NET SDK installation and required version (based on SDK version)
-	if err := checkDotnetSdkVersion(project.VersionMetadata.MinDotnetSdkVersion); err != nil {
+	if err := checkDotnetSdkVersion(ctx, project.VersionMetadata.MinDotnetSdkVersion); err != nil {
 		return err
 	}
 
@@ -80,7 +82,7 @@ func (o *testDotnetUnitOpts) Run(cmd *cobra.Command) error {
 	// Execute SDK tests one project at a time for clearer output
 	for _, projPath := range testProjects {
 		log.Info().Msg(styles.RenderBright(fmt.Sprintf("🔷 Run tests in %s", filepath.Base(projPath))))
-		if err := execChildTask(projPath, "dotnet", []string{"test"}); err != nil {
+		if err := execChildTask(ctx, projPath, "dotnet", []string{"test"}); err != nil {
 			return clierrors.Wrapf(err, "Unit tests failed in %s", projPath)
 		}
 	}
@@ -99,7 +101,7 @@ func (o *testDotnetUnitOpts) Run(cmd *cobra.Command) error {
 		if st, err := os.Stat(projPath); err == nil && st.IsDir() {
 			log.Info().Msg("")
 			log.Info().Msg(styles.RenderBright(fmt.Sprintf("🔷 Run tests in %s", filepath.Base(projPath))))
-			if err := execChildTask(projPath, "dotnet", []string{"test"}); err != nil {
+			if err := execChildTask(ctx, projPath, "dotnet", []string{"test"}); err != nil {
 				return clierrors.Wrapf(err, "Unit tests failed in %s", projPath)
 			}
 		}

--- a/cmd/test_integration.go
+++ b/cmd/test_integration.go
@@ -141,6 +141,7 @@ func (o *testIntegrationOpts) Prepare(cmd *cobra.Command, args []string) error {
 }
 
 func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
 	// Resolve project configuration
 	project, err := resolveProject()
 	if err != nil {
@@ -169,24 +170,24 @@ func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Ensure Docker is available (binary + daemon)
-	if err := checkDockerAvailable(); err != nil {
+	if err := checkDockerAvailable(ctx); err != nil {
 		return err
 	}
 
 	// Check Docker version: warn if using old versions
-	dockerVersionInfo, dockerUpgradeRecommended, err := checkDockerVersion()
+	dockerVersionInfo, dockerUpgradeRecommended, err := checkDockerVersion(ctx)
 	if err != nil {
 		log.Warn().Msgf("Warning: Failed to check Docker version: %v", err)
 	}
 
 	// Resolve docker build engine for integration tests
 	buildEngine := "buildkit"
-	if dockerSupportsBuildx() {
+	if dockerSupportsBuildx(ctx) {
 		buildEngine = "buildx"
 	}
 
 	// Check that the build engine is available
-	err = checkBuildEngineAvailable(buildEngine)
+	err = checkBuildEngineAvailable(ctx, buildEngine)
 	if err != nil {
 		return err
 	}
@@ -220,13 +221,25 @@ func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to create output directory %s: %w", o.flagOutputDir, err)
 	}
 
-	// Create a context with the configured timeout
-	ctx, cancel := context.WithTimeout(context.Background(), o.flagTimeout)
+	// Build the container images first (not subject to --timeout but still
+	// cancelable via Ctrl+C through cmd.Context()).
+	if !o.flagSkipBuild {
+		if err := o.buildDockerImages(ctx, project, serverImage, pwTsImage, pwNetImage, integrationTestsConfig); err != nil {
+			return fmt.Errorf("failed to build container images: %w", err)
+		}
+	} else {
+		log.Info().Msg("")
+		log.Info().Msg("Skipping container image build step due to --skip-build")
+	}
+
+	// Apply --timeout to the test phase, derived from cmd.Context() so Ctrl+C
+	// still cancels.
+	testRunCtx, cancel := context.WithTimeout(ctx, o.flagTimeout)
 	defer cancel()
 
 	// Build runtime context for test functions.
 	testCtx := integrationTestCtx{
-		ctx:                ctx,
+		ctx:                testRunCtx,
 		opts:               o,
 		project:            project,
 		serverImage:        serverImage,
@@ -235,20 +248,10 @@ func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
 		config:             integrationTestsConfig,
 	}
 
-	// Build the container images first (not subject to --timeout).
-	if !o.flagSkipBuild {
-		if err := o.buildDockerImages(project, serverImage, pwTsImage, pwNetImage, integrationTestsConfig); err != nil {
-			return fmt.Errorf("failed to build container images: %w", err)
-		}
-	} else {
-		log.Info().Msg("")
-		log.Info().Msg("Skipping container image build step due to --skip-build")
-	}
-
 	// Run all the active tests.
 	for _, t := range tests {
 		// Check if the timeout has been reached
-		if ctx.Err() != nil {
+		if testRunCtx.Err() != nil {
 			return fmt.Errorf("test run timed out after %s", o.flagTimeout)
 		}
 
@@ -257,7 +260,7 @@ func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
 		log.Info().Msg("")
 
 		runFn := t.run
-		if err := o.runTestCase(ctx, project, serverImage, integrationTestsConfig, t.displayName, func(server *testutil.BackgroundGameServer) error {
+		if err := o.runTestCase(testRunCtx, project, serverImage, integrationTestsConfig, t.displayName, func(server *testutil.BackgroundGameServer) error {
 			return runFn(testCtx, server)
 		}); err != nil {
 			return fmt.Errorf("test '%s' failed: %w", t.displayName, err)
@@ -537,11 +540,11 @@ func (o *testIntegrationOpts) debugNetworkConnectivity(ctx context.Context, proj
 // the server image, and additional testing images for Playwright.
 // Note: Docker builds are not subject to the --timeout flag as cancelling them mid-build
 // is complex and unreliable. Builds are typically fast when cached.
-func (o *testIntegrationOpts) buildDockerImages(project *metaproj.MetaplayProject, serverImage, pwTsImage, pwNetImage string, integrationTestsConfig *metaproj.IntegrationTestsConfig) error {
+func (o *testIntegrationOpts) buildDockerImages(ctx context.Context, project *metaproj.MetaplayProject, serverImage, pwTsImage, pwNetImage string, integrationTestsConfig *metaproj.IntegrationTestsConfig) error {
 	// Determine build engine
 	// \todo allow specifying this with a flag?
 	buildEngine := "buildkit"
-	if dockerSupportsBuildx() {
+	if dockerSupportsBuildx(ctx) {
 		buildEngine = "buildx"
 	}
 
@@ -566,7 +569,7 @@ func (o *testIntegrationOpts) buildDockerImages(project *metaproj.MetaplayProjec
 	log.Info().Msg(styles.RenderBright("🔷 Build server image"))
 	serverParams := commonParams
 	serverParams.imageName = serverImage
-	if err := buildDockerImage(serverParams); err != nil {
+	if err := buildDockerImage(ctx,serverParams); err != nil {
 		return fmt.Errorf("failed to build server image: %w", err)
 	}
 
@@ -576,7 +579,7 @@ func (o *testIntegrationOpts) buildDockerImages(project *metaproj.MetaplayProjec
 	pwTsParams := commonParams
 	pwTsParams.imageName = pwTsImage
 	pwTsParams.target = "playwright-ts-tests"
-	if err := buildDockerImage(pwTsParams); err != nil {
+	if err := buildDockerImage(ctx,pwTsParams); err != nil {
 		return fmt.Errorf("failed to build playwright-ts image: %w", err)
 	}
 
@@ -586,7 +589,7 @@ func (o *testIntegrationOpts) buildDockerImages(project *metaproj.MetaplayProjec
 	pwNetParams := commonParams
 	pwNetParams.imageName = pwNetImage
 	pwNetParams.target = "playwright-net-tests"
-	if err := buildDockerImage(pwNetParams); err != nil {
+	if err := buildDockerImage(ctx,pwNetParams); err != nil {
 		return fmt.Errorf("failed to build playwright-net image: %w", err)
 	}
 
@@ -594,9 +597,12 @@ func (o *testIntegrationOpts) buildDockerImages(project *metaproj.MetaplayProjec
 }
 
 // dockerSupportsBuildx returns true if docker buildx is available.
-func dockerSupportsBuildx() bool {
+func dockerSupportsBuildx(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return false
+	}
 	// Try `docker buildx version`
-	cmd := exec.Command("docker", "buildx", "version")
+	cmd := exec.CommandContext(ctx, "docker", "buildx", "version")
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/cmd/test_system.go
+++ b/cmd/test_system.go
@@ -53,6 +53,8 @@ func init() {
 func (o *testSystemOpts) Prepare(cmd *cobra.Command, args []string) error { return nil }
 
 func (o *testSystemOpts) Run(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
 	// Resolve project
 	project, err := resolveProject()
 	if err != nil {
@@ -64,7 +66,7 @@ func (o *testSystemOpts) Run(cmd *cobra.Command) error {
 	log.Info().Msg("")
 
 	// Check for .NET SDK installation and required version (based on SDK version)
-	if err := checkDotnetSdkVersion(project.VersionMetadata.MinDotnetSdkVersion); err != nil {
+	if err := checkDotnetSdkVersion(ctx, project.VersionMetadata.MinDotnetSdkVersion); err != nil {
 		return err
 	}
 
@@ -80,14 +82,14 @@ func (o *testSystemOpts) Run(cmd *cobra.Command) error {
 
 	// Install Playwright browsers.
 	log.Info().Msg(styles.RenderBright("🔷 Install Playwright browsers"))
-	if err := execChildTask(sdkSystemTestsDir, "playwright", []string{"install"}); err != nil {
+	if err := execChildTask(ctx, sdkSystemTestsDir, "playwright", []string{"install"}); err != nil {
 		return clierrors.Wrapf(err, "Playwright install failed in %s", sdkSystemTestsDir)
 	}
 
 	// SDK core system tests
 	log.Info().Msg("")
 	log.Info().Msg(styles.RenderBright("🔷 Run tests in MetaplaySDK/Backend/System.Tests"))
-	if err := execChildTask(sdkSystemTestsDir, "dotnet", []string{"test"}); err != nil {
+	if err := execChildTask(ctx, sdkSystemTestsDir, "dotnet", []string{"test"}); err != nil {
 		return clierrors.Wrapf(err, "SDK system tests failed in %s", sdkSystemTestsDir)
 	}
 
@@ -97,7 +99,7 @@ func (o *testSystemOpts) Run(cmd *cobra.Command) error {
 	userSystemTestsDir := filepath.Join(userBackendRootDir, "System.Tests")
 	if st, err := os.Stat(userSystemTestsDir); err == nil && st.IsDir() {
 		log.Info().Msg(styles.RenderBright("🔷 Run tests in Backend/System.Tests"))
-		if err := execChildTask(userSystemTestsDir, "dotnet", []string{"test"}); err != nil {
+		if err := execChildTask(ctx, userSystemTestsDir, "dotnet", []string{"test"}); err != nil {
 			return clierrors.Wrapf(err, "Project system tests failed in %s", userSystemTestsDir)
 		}
 	} else {


### PR DESCRIPTION
## Summary

Pressing Ctrl+C during `metaplay dev dashboard` (and other long-running `dev *` workflows) printed misleading guidance like:

```
Have you tried running `metaplay dev clean-dashboard-artifacts`? …
Error: failed to run the LiveOps Dashboard: binary exited with error: exit status 1
```

…even though the failure was a deliberate user interrupt. Fixes [PLA-1205](https://linear.app/metaplay/issue/PLA-1205).

## What changed

- **`cmd/dotnet_helper.go`**: introduce `SignaledError`, a wrapper returned by `execChildInteractive` when the child was killed by a forwarded SIGINT/SIGTERM. Detection uses both a mutex-tracked `forwardedSig` (works on Windows) and `ProcessState.ExitCode() == -1` (Unix). Also fix a long-standing goroutine leak — the signal forwarder never exited — by deferring `signal.Stop` + `close(signalChan)`. Drop the broken `if exitErr, ok := …; ok && ExitCode() != 0` check that swallowed non-`ExitError` failures.
- **`cmd/root.go`**: centralized handling in `runCommand` — `errors.As(err, &sigErr)` → silent `os.Exit(130)` (POSIX `128 + SIGINT`). No call-site changes needed; tolerates Ctrl+C in all 8 current `execChildInteractive` callers and any future ones.
- **`cmd/dev_dashboard.go`**: dropped the pre-error `log.Info("Have you tried …")` lines. Moved the hint into `clierrors.WithSuggestion()` so it only renders on real failures (as the standard `Hint:` line), not on Ctrl+C. Also converted the "no custom dashboard" error to `clierrors.New` for consistency.

## Why centralize rather than per-call-site

The original proposal touched 6 call sites and missed 3 more (`cmd/build_dashboard.go` ×2, `cmd/init_dashboard.go`). Detecting `SignaledError` once in `runCommand` covers all callers — current and future — without churn.

## Output from MacOS

No more error on CTRL+C:
```
❯ go run . -p ../sdk/Samples/Idler dev dashboard
Metaplay CLI dev, interactive mode

Run LiveOps Dashboard Locally

✓ Node.js detected: 24.16.0 [minimum: 24.13.0] [warning: minor version is more recent; downgrade if you encounter any problems]
✓ pnpm detected:    11.2.2 [minimum: 11.1.3] [warning: minor version is more recent; downgrade if you encounter any problems]

Scope: all 28 workspace projects
Already up to date
Done in 78ms using pnpm v11.1.3
$ vite
You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
3:37:42 PM [vite] (client) Re-optimizing dependencies because lockfile has changed

  VITE v8.0.10  ready in 506 ms

  ➜  Local:   http://localhost:5551/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
3:37:44 PM [vite] (client) [optimizer] scanning dependencies...
^C
Interrupted, cleaning up... (press Ctrl+C again to force quit)
[ELIFECYCLE] Command failed.
exit status 130
```

Error still shows on broken dash:
```
❯ go run . -p ../sdk/Samples/Idler build dashboard
Metaplay CLI dev, interactive mode

Build LiveOps Dashboard Locally

Output directory: Backend/Dashboard/dist

✓ Node.js detected: 24.16.0 [minimum: 24.13.0] [warning: minor version is more recent; downgrade if you encounter any problems]
✓ pnpm detected:    11.2.2 [minimum: 11.1.3] [warning: minor version is more recent; downgrade if you encounter any problems]

Install dashboard dependencies...
> pnpm install
Scope: all 28 workspace projects
.../../../MetaplaySDK/Frontend/Bootstrap | [WARN] deprecated bootstrap@4.6.2
.../../../MetaplaySDK/Frontend/Bootstrap | [WARN] deprecated popper.js@1.16.1
../../../../docs                         | [WARN] deprecated @types/tar@7.0.87
[ERR_PNPM_FETCH_404] GET https://registry.npmjs.org/non-existent-ZZZZZZZZ: Not Found - 404

This error happened while installing a direct dependency of /Users/teemu/Documents/Metaplay/sdk/Samples/Idler/Backend/Dashboard

non-existent-ZZZZZZZZ is not in the npm registry, or you have no permission to fetch it.

An authorization header was used: Bearer npm_[hidden]
../../../..                              | Progress: resolved 203, reused 203, downloaded 0, added 0
Error: Failed to install LiveOps Dashboard dependencies (binary exited with error: exit status 1)

Hint: Try running 'metaplay dev clean-dashboard-artifacts' to remove build artifacts, then retry
exit status 1
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go run . -p ../sdk/Samples/Idler dev dashboard` → Ctrl+C → exits silently with code 130, no "Have you tried" noise
- [x] Break the dashboard project, run the same → real failure still shows the `Hint:` suggestion
- [x] Re-run on Windows if accessible (signal detection path differs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)