### PR TITLE
Add allowBuilds to scaffolded pnpm-workspace.yaml for R33+

### DIFF
--- a/cmd/dashboard_helper.go
+++ b/cmd/dashboard_helper.go
@@ -61,7 +61,7 @@ func checkNodeVersion(ctx context.Context, recommendedVersion *version.Version) 
 	requiredMajorVersion := recommendedVersion.Segments()[0]
 	requiredMinorVersion := recommendedVersion.Segments()[1]
 	if installedMajorVersion > requiredMajorVersion {
-		badge = badge + " " + styles.RenderWarning(fmt.Sprintf("[warning: major version is more recent than expected v%d.x.y; downgrade if you encounter any problems]", requiredMajorVersion))
+		badge = badge + " " + styles.RenderWarning(fmt.Sprintf("[warning: major version is more recent than expected v%s; downgrade if you encounter any problems]", recommendedVersion))
 	} else if installedMinorVersion > requiredMinorVersion {
 		badge = badge + " " + styles.RenderWarning("[warning: minor version is more recent; downgrade if you encounter any problems]")
 	}
@@ -109,7 +109,7 @@ func checkPnpmVersion(ctx context.Context, recommendedVersion *version.Version) 
 
 	// If installed major version is more recent than expected, fail.
 	if installedMajorVersion > requiredMajorVersion {
-		return fmt.Errorf("detected pnpm version %s is too recent; expecting version v%d.x.y", installedVersion, requiredMajorVersion)
+		return fmt.Errorf("detected pnpm version %s is too recent; expecting v%s", installedVersion, recommendedVersion)
 	}
 
 	// Print the info.

--- a/cmd/init_dashboard.go
+++ b/cmd/init_dashboard.go
@@ -136,11 +136,14 @@ func (o *initDashboardOpts) Run(cmd *cobra.Command) error {
 
 	// Render pnpm-workspace.yaml content. SDK R37 introduced pnpm 11, which
 	// fails install if native-build deps aren't listed in 'allowBuilds:'.
+	// We also emit the block on R33-R36 (pnpm 10.9+) as forward-proofing
+	// in case someone upgrades their local pnpm. R32 (pnpm 10.6.2) doesn't
+	// honor the field.
 	// The package list below is for SDK 37.x; revisit when bumping pnpm or
 	// when the scaffolded dashboard's dep tree changes.
-	// '37.0.0-aaaaa' is the lowest possible pre-release of 37.0.0 so R37
-	// preview builds (e.g. 37.0.0-alpha.1) are included.
-	minSdkVersionPnpmAllowBuilds := version.Must(version.NewVersion("37.0.0-aaaaa"))
+	// '33.0.0-aaaaa' is the lowest possible pre-release of 33.0.0 so R33
+	// preview builds (e.g. 33.0.0-alpha.1) are included.
+	minSdkVersionPnpmAllowBuilds := version.Must(version.NewVersion("33.0.0-aaaaa"))
 	var allowBuildsPackages []string
 	if !project.VersionMetadata.SdkVersion.LessThan(minSdkVersionPnpmAllowBuilds) {
 		allowBuildsPackages = []string{

--- a/cmd/init_dashboard.go
+++ b/cmd/init_dashboard.go
@@ -136,14 +136,14 @@ func (o *initDashboardOpts) Run(cmd *cobra.Command) error {
 
 	// Render pnpm-workspace.yaml content. SDK R37 introduced pnpm 11, which
 	// fails install if native-build deps aren't listed in 'allowBuilds:'.
-	// We also emit the block on R33-R36 (pnpm 10.9+) as forward-proofing
-	// in case someone upgrades their local pnpm. R32 (pnpm 10.6.2) doesn't
-	// honor the field.
+	// We also emit the block on R33-R36 as forward-proofing in case someone
+	// upgrades their local pnpm. R32 ships a pnpm too old to honor the field.
 	// The package list below is for SDK 37.x; revisit when bumping pnpm or
 	// when the scaffolded dashboard's dep tree changes.
-	// '33.0.0-aaaaa' is the lowest possible pre-release of 33.0.0 so R33
-	// preview builds (e.g. 33.0.0-alpha.1) are included.
-	minSdkVersionPnpmAllowBuilds := version.Must(version.NewVersion("33.0.0-aaaaa"))
+	// '33.0.0-0' is the lowest possible pre-release of 33.0.0 per SemVer 2.0
+	// (numeric pre-release identifiers sort below all alphanumeric ones), so
+	// any R33 pre-release tag is included.
+	minSdkVersionPnpmAllowBuilds := version.Must(version.NewVersion("33.0.0-0"))
 	var allowBuildsPackages []string
 	if !project.VersionMetadata.SdkVersion.LessThan(minSdkVersionPnpmAllowBuilds) {
 		allowBuildsPackages = []string{

--- a/cmd/init_dashboard.go
+++ b/cmd/init_dashboard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
+	"github.com/hashicorp/go-version"
 	clierrors "github.com/metaplay/cli/internal/errors"
 	"github.com/metaplay/cli/internal/tui"
 	"github.com/metaplay/cli/pkg/filesetwriter"
@@ -64,16 +65,36 @@ func (o *initDashboardOpts) Prepare(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// renderPnpmWorkspaceContent renders a pnpm-workspace.yaml with the given package entries.
-func renderPnpmWorkspaceContent(entries []string) ([]byte, error) {
+// renderPnpmWorkspaceContent renders a pnpm-workspace.yaml with the given package
+// entries. If allowBuildsPackages is non-empty, also emits an 'allowBuilds:'
+// block listing those packages (required by pnpm 11 to permit their build
+// scripts).
+func renderPnpmWorkspaceContent(entries []string, allowBuildsPackages []string) ([]byte, error) {
 	log.Debug().Msgf("Render pnpm-workspace.yaml with entries:")
 	for _, entry := range entries {
 		log.Debug().Msgf("  %s", entry)
 	}
+
+	if len(allowBuildsPackages) == 0 {
+		data := struct {
+			Packages []string `yaml:"packages"`
+		}{
+			Packages: entries,
+		}
+		return yaml.Marshal(data)
+	}
+
+	allowBuilds := make(map[string]bool, len(allowBuildsPackages))
+	for _, pkg := range allowBuildsPackages {
+		allowBuilds[pkg] = true
+	}
+
 	data := struct {
-		Packages []string `yaml:"packages"`
+		Packages    []string        `yaml:"packages"`
+		AllowBuilds map[string]bool `yaml:"allowBuilds"`
 	}{
-		Packages: entries,
+		Packages:    entries,
+		AllowBuilds: allowBuilds,
 	}
 	return yaml.Marshal(data)
 }
@@ -113,11 +134,25 @@ func (o *initDashboardOpts) Run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to collect dashboard template files: %w", err)
 	}
 
-	// Render pnpm-workspace.yaml content
+	// Render pnpm-workspace.yaml content. SDK R37 introduced pnpm 11, which
+	// fails install if native-build deps aren't listed in 'allowBuilds:'.
+	// The package list below is for SDK 37.x; revisit when bumping pnpm or
+	// when the scaffolded dashboard's dep tree changes.
+	// '37.0.0-aaaaa' is the lowest possible pre-release of 37.0.0 so R37
+	// preview builds (e.g. 37.0.0-alpha.1) are included.
+	minSdkVersionPnpmAllowBuilds := version.Must(version.NewVersion("37.0.0-aaaaa"))
+	var allowBuildsPackages []string
+	if !project.VersionMetadata.SdkVersion.LessThan(minSdkVersionPnpmAllowBuilds) {
+		allowBuildsPackages = []string{
+			"@parcel/watcher",
+			"bootstrap-vue",
+			"esbuild",
+		}
+	}
 	pnpmContent, err := renderPnpmWorkspaceContent([]string{
 		filepath.ToSlash(filepath.Join(project.Config.SdkRootDir, "Frontend", "*")),
 		filepath.ToSlash(dashboardDirRelative),
-	})
+	}, allowBuildsPackages)
 	if err != nil {
 		return fmt.Errorf("failed to render pnpm-workspace.yaml: %w", err)
 	}

--- a/cmd/init_dashboard_test.go
+++ b/cmd/init_dashboard_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderPnpmWorkspaceContent_WithAllowBuilds(t *testing.T) {
+	got, err := renderPnpmWorkspaceContent(
+		[]string{"MetaplaySDK/Frontend/*", "Backend/Dashboard"},
+		[]string{"@parcel/watcher", "bootstrap-vue", "esbuild"},
+	)
+	if err != nil {
+		t.Fatalf("renderPnpmWorkspaceContent returned error: %v", err)
+	}
+
+	out := string(got)
+
+	wantContains := []string{
+		"packages:",
+		"- MetaplaySDK/Frontend/*",
+		"- Backend/Dashboard",
+		"allowBuilds:",
+		"\"@parcel/watcher\": true",
+		"bootstrap-vue: true",
+		"esbuild: true",
+	}
+	for _, w := range wantContains {
+		if !strings.Contains(out, w) {
+			t.Errorf("expected output to contain %q, got:\n%s", w, out)
+		}
+	}
+}
+
+func TestRenderPnpmWorkspaceContent_WithoutAllowBuilds(t *testing.T) {
+	got, err := renderPnpmWorkspaceContent(
+		[]string{"MetaplaySDK/Frontend/*", "Backend/Dashboard"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("renderPnpmWorkspaceContent returned error: %v", err)
+	}
+
+	out := string(got)
+
+	if !strings.Contains(out, "packages:") {
+		t.Errorf("expected 'packages:' in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "allowBuilds") {
+		t.Errorf("did not expect 'allowBuilds' in output, got:\n%s", out)
+	}
+}

--- a/cmd/init_dashboard_test.go
+++ b/cmd/init_dashboard_test.go
@@ -37,20 +37,25 @@ func TestRenderPnpmWorkspaceContent_WithAllowBuilds(t *testing.T) {
 }
 
 func TestRenderPnpmWorkspaceContent_WithoutAllowBuilds(t *testing.T) {
-	got, err := renderPnpmWorkspaceContent(
-		[]string{"MetaplaySDK/Frontend/*", "Backend/Dashboard"},
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("renderPnpmWorkspaceContent returned error: %v", err)
-	}
-
-	out := string(got)
-
-	if !strings.Contains(out, "packages:") {
-		t.Errorf("expected 'packages:' in output, got:\n%s", out)
-	}
-	if strings.Contains(out, "allowBuilds") {
-		t.Errorf("did not expect 'allowBuilds' in output, got:\n%s", out)
+	for name, allowBuilds := range map[string][]string{
+		"nil slice":   nil,
+		"empty slice": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := renderPnpmWorkspaceContent(
+				[]string{"MetaplaySDK/Frontend/*", "Backend/Dashboard"},
+				allowBuilds,
+			)
+			if err != nil {
+				t.Fatalf("renderPnpmWorkspaceContent returned error: %v", err)
+			}
+			out := string(got)
+			if !strings.Contains(out, "packages:") {
+				t.Errorf("expected 'packages:' in output, got:\n%s", out)
+			}
+			if strings.Contains(out, "allowBuilds") {
+				t.Errorf("did not expect 'allowBuilds' in output, got:\n%s", out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `metaplay init dashboard` now emits an `allowBuilds:` block in the scaffolded `pnpm-workspace.yaml` when the project's SDK is R33+. Without it, `pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS` on R37 (which bumps pnpm to 11 with strict-by-default build-script approval).
- Gated on SDK version `>= 33.0.0-0` so any R33 pre-release tag is included (`-0` is the canonical lowest pre-release per SemVer 2.0 — numeric IDs sort below alphanumeric).
- R33-R36 don't strictly need this (pnpm 10.x tolerates a missing block), but emitting it is forward-proofing in case a user upgrades their local pnpm. R32 (pnpm 10.6.2) ships a pnpm too old to honor the field and stays excluded.
- Pre-R33 projects are unaffected — output is byte-identical to before.
- Listed packages (`@parcel/watcher`, `bootstrap-vue`, `esbuild`) are the ones pnpm 11 flagged in the failing SDK CI run; comment notes the list is SDK 37.x-specific and should be revisited on future SDK/pnpm bumps.

## Test plan

- [x] `make` (build)
- [x] `go test -run TestRenderPnpmWorkspaceContent ./cmd/` — covers with-allowBuilds and without-allowBuilds (nil and empty slice)
- [x] Manual: `metaplay init dashboard` against an R37 checkout — `pnpm install` should succeed
- [x] Manual: `metaplay init dashboard` against an R36 checkout — should scaffold with `allowBuilds:` block