### PR TITLE
Polish Ctrl+C UX: cmd.exe shim kill, graceful shutdown, force-quit

### DIFF
--- a/cmd/build_image.go
+++ b/cmd/build_image.go
@@ -342,10 +342,19 @@ func executeCommand(ctx context.Context, workingDir string, env []string, comman
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = workingDir
-	if err := cmd.Start(); err != nil {
+	// On ctx cancellation, don't immediately TerminateProcess/SIGKILL the
+	// child — the OS already delivers Ctrl+C to the whole foreground process
+	// group (Unix) or console-attached processes (Windows). docker CLI needs
+	// that window to forward SIGTERM to its own descendants (a --rm
+	// container) and to drain its daemon-side build cancel. applyCancelPolicy
+	// installs a no-op Cancel + 10 s WaitDelay safety net.
+	setCleanup := applyCancelPolicy(cmd)
+	cleanup, err := startCmd(cmd)
+	if err != nil {
 		return err
 	}
-	defer killOnExit(cmd)()
+	setCleanup(cleanup)
+	defer cleanup()
 	return cmd.Wait()
 }
 

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	clierrors "github.com/metaplay/cli/internal/errors"
@@ -33,6 +34,58 @@ type SignaledError struct {
 
 func (e *SignaledError) Error() string { return e.Err.Error() }
 func (e *SignaledError) Unwrap() error { return e.Err }
+
+// isCmdShim reports whether cmd.Path resolves to a Windows .cmd or .bat
+// script. exec.Cmd invokes those via cmd.exe, which shows
+// "Terminate batch job (Y/N)?" on Ctrl+C and blocks until answered —
+// callers use this to opt into a faster Cancel policy (kill the whole
+// process tree atomically) instead of giving the child a graceful window.
+func isCmdShim(path string) bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	p := strings.ToLower(path)
+	return strings.HasSuffix(p, ".cmd") || strings.HasSuffix(p, ".bat")
+}
+
+// applyCancelPolicy configures cmd.Cancel and cmd.WaitDelay for graceful
+// vs. fast shutdown when ctx is canceled. It returns a setter the caller
+// must invoke after startCmd to wire the Job-Object cleanup into Cancel.
+//
+//   - .cmd/.bat shims (pnpm.cmd, playwright.cmd …): close the Job Object
+//     immediately on cancel. Otherwise cmd.exe would prompt
+//     "Terminate batch job (Y/N)?" and block until WaitDelay force-kills
+//     it. WaitDelay stays as a small safety net.
+//   - native executables (dotnet, docker, …): no-op Cancel + 10 s
+//     WaitDelay. The child handles its own SIGINT/CTRL_C_EVENT
+//     (forwarding to containers, flushing build state, etc.); we only
+//     force-kill if it wedges.
+func applyCancelPolicy(cmd *exec.Cmd) func(cleanup func()) {
+	var (
+		mu      sync.Mutex
+		cleanup func()
+	)
+	if isCmdShim(cmd.Path) {
+		cmd.Cancel = func() error {
+			mu.Lock()
+			c := cleanup
+			mu.Unlock()
+			if c != nil {
+				c()
+			}
+			return nil
+		}
+		cmd.WaitDelay = 2 * time.Second
+	} else {
+		cmd.Cancel = func() error { return nil }
+		cmd.WaitDelay = 10 * time.Second
+	}
+	return func(c func()) {
+		mu.Lock()
+		cleanup = c
+		mu.Unlock()
+	}
+}
 
 // Environment variables to pass to all dotnet commands.
 var commonDotnetEnvVars = []string{
@@ -121,14 +174,17 @@ func execChildTask(ctx context.Context, workingDir string, binary string, args [
 	cmd.Dir = workingDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	setCleanup := applyCancelPolicy(cmd)
 
 	log.Info().Msg(styles.RenderMuted(fmt.Sprintf("%s$ %s %s", workingDir, binary, strings.Join(args, " "))))
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start the binary: %w", err)
+	cleanup, err := startCmd(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to start %s: %w", binary, err)
 	}
-	defer killOnExit(cmd)()
+	setCleanup(cleanup)
+	defer cleanup()
 	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("failed to build the project: %w", err)
+		return fmt.Errorf("%s exited with error: %w", binary, err)
 	}
 
 	return nil
@@ -159,9 +215,20 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 		cmd.Env = append(os.Environ(), extraEnv...)
 	}
 
-	// Create a channel to forward signals to the subprocess. Track whether we
-	// forwarded one so we can mark the resulting error as signal-induced; this
-	// works on Windows too (where ExitCode() != -1 for Ctrl+C).
+	// We forward signals to the child manually (see goroutine below) and
+	// also rely on OS-level signal delivery (process group on Unix, console
+	// attachment on Windows). exec.CommandContext's default Cancel is
+	// Process.Kill — that would race ahead of our graceful signal and
+	// SIGKILL/TerminateProcess the child mid-shutdown. applyCancelPolicy
+	// installs a no-op (or, for .cmd/.bat shims on Windows, a Job-Object-
+	// closing) Cancel along with a WaitDelay safety net.
+	setCleanup := applyCancelPolicy(cmd)
+
+	// Create a channel to forward signals to the subprocess. Track whether
+	// we forwarded one so we can mark the resulting error as signal-induced
+	// — needed on Windows in particular, where TerminateProcess just sets
+	// an exit code and ProcessState can't distinguish signal-kill from a
+	// normal failure.
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
@@ -175,15 +242,16 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 		close(signalChan)
 	}()
 
-	// Start the process
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start the binary: %w", err)
+	// Start the child. On Windows this attaches it to a Job Object so the
+	// entire process tree dies together when we exit — without that, the
+	// .cmd shims that fork pnpm/npm leave node descendants alive on Ctrl+C.
+	// startCmd is a thin wrapper over cmd.Start on other platforms.
+	cleanup, err := startCmd(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to start %s: %w", binary, err)
 	}
-
-	// On Windows, attach the child to a Job Object so the entire process
-	// tree dies together when we exit. Without this, pnpm/npm .cmd shims
-	// leave node descendants alive on Ctrl+C. No-op on other platforms.
-	defer killOnExit(cmd)()
+	setCleanup(cleanup)
+	defer cleanup()
 
 	// Goroutine to forward signals to the subprocess. Exits when signalChan is closed.
 	go func() {
@@ -198,7 +266,7 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 	}()
 
 	// Wait for the subprocess to complete
-	err := cmd.Wait()
+	err = cmd.Wait()
 	if err == nil {
 		return nil
 	}
@@ -209,13 +277,11 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 	sig := forwardedSig
 	mu.Unlock()
 
-	// On Unix, ExitCode() == -1 indicates the child was killed by a signal.
-	// On Windows, that signal won't be observable that way, so we also fall
-	// back to whether we forwarded one ourselves.
-	killedBySignal := sig != nil
-	if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
-		killedBySignal = true
-	}
+	// On Unix, syscall.WaitStatus.Signaled() reports signal-induced exit
+	// reliably (unlike ExitCode == -1, which also fires for processes that
+	// haven't exited). Windows can't distinguish via ProcessState, so we
+	// fall back to whether we forwarded a signal ourselves.
+	killedBySignal := sig != nil || wasKilledBySignal(cmd.ProcessState)
 
 	if killedBySignal {
 		return &SignaledError{Signal: sig, Err: wrapped}

--- a/cmd/process_tree_other.go
+++ b/cmd/process_tree_other.go
@@ -1,17 +1,40 @@
+//go:build !windows
+
 /*
  * Copyright Metaplay. Licensed under the Apache-2.0 license.
  */
 
-//go:build !windows
-
 package cmd
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
 
-// killOnExit is a no-op on Unix: process groups + SIGTERM/SIGKILL already
-// handle descendant cleanup naturally. The Windows variant attaches the
-// child to a Job Object so killing the parent atomically tears down the
-// whole subprocess tree.
-func killOnExit(_ *exec.Cmd) func() {
-	return func() {}
+// startCmd starts the command and returns a cleanup function that callers
+// should defer. On Unix it's a thin wrapper over cmd.Start — process group
+// + SIGTERM/SIGKILL naturally tear down descendants. The Windows variant
+// goes through a job-object dance to atomically kill the whole subprocess
+// tree on cancellation.
+func startCmd(cmd *exec.Cmd) (func(), error) {
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return func() {}, nil
+}
+
+// wasKilledBySignal reports whether the process was terminated by a signal
+// rather than exiting normally. Relies on syscall.WaitStatus.Signaled() —
+// more reliable than checking ExitCode == -1, which also fires for processes
+// that haven't yet exited.
+func wasKilledBySignal(ps *os.ProcessState) bool {
+	if ps == nil {
+		return false
+	}
+	ws, ok := ps.Sys().(syscall.WaitStatus)
+	if !ok {
+		return false
+	}
+	return ws.Signaled()
 }

--- a/cmd/process_tree_windows.go
+++ b/cmd/process_tree_windows.go
@@ -5,39 +5,95 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"sync"
+	"syscall"
 	"unsafe"
 
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows"
 )
 
-// killOnExit attaches cmd.Process to a Windows Job Object configured with
-// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, then returns a cleanup func. When the
-// cleanup func runs (or the parent process dies for any reason and the
-// handle is released), the kernel terminates every process in the job —
-// the child and all of its descendants — atomically.
+// startCmd starts cmd inside a Windows Job Object so that closing the
+// returned cleanup func (or letting our process die) atomically terminates
+// the child and every descendant.
 //
-// This matters on Windows because tools like pnpm/npm are installed as
-// .cmd shims: `exec.Command("pnpm", ...)` actually launches cmd.exe to
-// run pnpm.cmd, which spawns node.exe, which spawns its own worker
-// processes. CTRL_C_EVENT propagation across that chain is unreliable —
-// the immediate cmd.exe may catch the signal and prompt "Terminate batch
-// job (Y/N)?" while the node descendants stay alive as orphans. With the
-// job object, killing the parent reliably tears down the whole tree.
+// To win the race against descendants spawning before we can put the child
+// in the job, we create the process with CREATE_SUSPENDED, attach it to
+// the job, and only then resume its main thread. Any process spawned by
+// the child after that point inherits the job automatically.
 //
-// Must be called after cmd.Start(). On failure, returns a no-op cleanup
-// and logs at debug — the caller continues without job protection.
-func killOnExit(cmd *exec.Cmd) func() {
-	if cmd.Process == nil {
-		return func() {}
+// This matters because tools like pnpm/npm are installed as .cmd shims:
+// `exec.Command("pnpm", ...)` actually launches cmd.exe to run pnpm.cmd,
+// which spawns node.exe, which spawns its own worker processes. CTRL_C_EVENT
+// propagation across that chain is unreliable — the immediate cmd.exe may
+// catch the signal and prompt "Terminate batch job (Y/N)?" while the node
+// descendants stay alive as orphans. With the job object, killing the parent
+// reliably tears down the whole tree.
+func startCmd(cmd *exec.Cmd) (func(), error) {
+	job, jobErr := prepareJob()
+	if jobErr != nil {
+		// Job setup failed; degrade gracefully to a plain Start. Descendants
+		// will outlive cancellation, but we don't want job-object problems
+		// to break the build.
+		log.Debug().Err(jobErr).Msg("Job object setup failed; subprocess tree may outlive cancellation")
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
+		return func() {}, nil
 	}
 
+	// Create the child suspended so we can attach it to the job before it
+	// can spawn anything.
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
+
+	if err := cmd.Start(); err != nil {
+		_ = windows.CloseHandle(job)
+		return nil, err
+	}
+
+	pid := uint32(cmd.Process.Pid)
+	assignErr := assignProcessToJob(job, pid)
+
+	// We MUST resume the thread no matter what — leaving it suspended hangs
+	// cmd.Wait forever. If we couldn't assign to the job, the cleanup func
+	// becomes a no-op, but the process still runs to completion.
+	if err := resumeProcessThreads(pid); err != nil {
+		// Truly stuck: process is suspended and we can't unstick it. Best
+		// effort is to kill it and Wait so exec.Cmd's internal watchdog
+		// goroutine exits (cmd.Wait signals ctxDone; without it the
+		// goroutine lives until ctx.Done fires).
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("failed to resume suspended child (pid %d): %w", pid, err)
+	}
+
+	if assignErr != nil {
+		log.Debug().Err(assignErr).Uint32("pid", pid).Msg("AssignProcessToJobObject failed; subprocess tree may outlive cancellation")
+		_ = windows.CloseHandle(job)
+		return func() {}, nil
+	}
+
+	// Wrap CloseHandle in sync.Once so callers can invoke cleanup more than
+	// once (e.g. from both cmd.Cancel and a deferred call) without risking
+	// a double-close on a recycled handle.
+	var once sync.Once
+	return func() { once.Do(func() { _ = windows.CloseHandle(job) }) }, nil
+}
+
+// prepareJob creates a Job Object configured to terminate every process in
+// the job when the last handle is closed.
+func prepareJob() (windows.Handle, error) {
 	job, err := windows.CreateJobObject(nil, nil)
 	if err != nil {
-		log.Debug().Err(err).Msg("CreateJobObject failed; subprocess tree may outlive cancellation")
-		return func() {}
+		return 0, fmt.Errorf("CreateJobObject: %w", err)
 	}
 
 	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
@@ -52,30 +108,75 @@ func killOnExit(cmd *exec.Cmd) func() {
 		uint32(unsafe.Sizeof(info)),
 	); err != nil {
 		_ = windows.CloseHandle(job)
-		log.Debug().Err(err).Msg("SetInformationJobObject failed; subprocess tree may outlive cancellation")
-		return func() {}
+		return 0, fmt.Errorf("SetInformationJobObject: %w", err)
 	}
+	return job, nil
+}
 
-	// AssignProcessToJobObject needs PROCESS_TERMINATE | PROCESS_SET_QUOTA
-	// on the target handle. Go's os.Process keeps its own handle but doesn't
-	// expose it, so we open a fresh one by PID.
+// assignProcessToJob opens a fresh handle to pid with the rights
+// AssignProcessToJobObject needs (Go's os.Process keeps its own handle but
+// doesn't expose it) and attaches it.
+func assignProcessToJob(job windows.Handle, pid uint32) error {
 	proc, err := windows.OpenProcess(
 		windows.PROCESS_TERMINATE|windows.PROCESS_SET_QUOTA,
 		false,
-		uint32(cmd.Process.Pid),
+		pid,
 	)
 	if err != nil {
-		_ = windows.CloseHandle(job)
-		log.Debug().Err(err).Msg("OpenProcess failed; subprocess tree may outlive cancellation")
-		return func() {}
+		return fmt.Errorf("OpenProcess: %w", err)
 	}
 	defer windows.CloseHandle(proc)
-
 	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
-		_ = windows.CloseHandle(job)
-		log.Debug().Err(err).Msg(fmt.Sprintf("AssignProcessToJobObject failed for pid %d; subprocess tree may outlive cancellation", cmd.Process.Pid))
-		return func() {}
+		return fmt.Errorf("AssignProcessToJobObject: %w", err)
+	}
+	return nil
+}
+
+// resumeProcessThreads resumes every thread of pid that is currently
+// suspended. We just created the process with CREATE_SUSPENDED so it has a
+// single suspended main thread, but enumerating-and-resuming is robust
+// against whatever the OS hands us.
+func resumeProcessThreads(pid uint32) error {
+	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("CreateToolhelp32Snapshot: %w", err)
+	}
+	defer windows.CloseHandle(snap)
+
+	var te windows.ThreadEntry32
+	te.Size = uint32(unsafe.Sizeof(te))
+	if err := windows.Thread32First(snap, &te); err != nil {
+		return fmt.Errorf("Thread32First: %w", err)
 	}
 
-	return func() { _ = windows.CloseHandle(job) }
+	resumed := 0
+	for {
+		if te.OwnerProcessID == pid {
+			th, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, te.ThreadID)
+			if err == nil {
+				_, _ = windows.ResumeThread(th)
+				_ = windows.CloseHandle(th)
+				resumed++
+			}
+		}
+		if err := windows.Thread32Next(snap, &te); err != nil {
+			// Thread32Next returns ERROR_NO_MORE_FILES at the end of the snapshot.
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return fmt.Errorf("Thread32Next: %w", err)
+		}
+	}
+	if resumed == 0 {
+		return fmt.Errorf("no threads found for pid %d", pid)
+	}
+	return nil
+}
+
+// wasKilledBySignal: Windows doesn't surface signal-induced termination via
+// ProcessState (TerminateProcess sets an arbitrary exit code, and even
+// Ctrl+C handlers may set their own). Callers must track forwarded signals
+// themselves; this helper exists for cross-platform symmetry.
+func wasKilledBySignal(_ *os.ProcessState) bool {
+	return false
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -350,7 +350,7 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		err := opts.Prepare(cmd, args)
 		if err != nil {
 			if wasInterrupted(cmd, err) {
-				os.Exit(130)
+				exitInterrupted()
 			}
 			// Show usage help for Prepare errors that are either explicit usage errors
 			// or plain Go errors (which are assumed to be usage errors since Prepare
@@ -366,7 +366,7 @@ func runCommand(opts CommandOptions) func(cmd *cobra.Command, args []string) {
 		err = opts.Run(cmd)
 		if err != nil {
 			if wasInterrupted(cmd, err) {
-				os.Exit(130)
+				exitInterrupted()
 			}
 			// Only show usage for explicit usage errors from Run()
 			if clierrors.IsUsageError(err) {
@@ -401,6 +401,17 @@ func wasInterrupted(cmd *cobra.Command, err error) bool {
 		return true
 	}
 	return false
+}
+
+// exitInterrupted prints a clean trailing acknowledgement and exits with
+// the POSIX SIGINT convention (128 + 2). The trailing line gives the user
+// closure after subprocess output — e.g. docker prints
+// "ERROR: failed to build: failed to solve: Canceled: context canceled"
+// on its way out and that shouldn't be the last thing the user sees.
+func exitInterrupted() {
+	stderrLogger.Info().Msg("")
+	stderrLogger.Info().Msg(styles.RenderMuted("Canceled."))
+	os.Exit(130)
 }
 
 // isCLIError checks if the error is a CLIError type.

--- a/cmd/test_integration.go
+++ b/cmd/test_integration.go
@@ -569,7 +569,7 @@ func (o *testIntegrationOpts) buildDockerImages(ctx context.Context, project *me
 	log.Info().Msg(styles.RenderBright("🔷 Build server image"))
 	serverParams := commonParams
 	serverParams.imageName = serverImage
-	if err := buildDockerImage(ctx,serverParams); err != nil {
+	if err := buildDockerImage(ctx, serverParams); err != nil {
 		return fmt.Errorf("failed to build server image: %w", err)
 	}
 
@@ -579,7 +579,7 @@ func (o *testIntegrationOpts) buildDockerImages(ctx context.Context, project *me
 	pwTsParams := commonParams
 	pwTsParams.imageName = pwTsImage
 	pwTsParams.target = "playwright-ts-tests"
-	if err := buildDockerImage(ctx,pwTsParams); err != nil {
+	if err := buildDockerImage(ctx, pwTsParams); err != nil {
 		return fmt.Errorf("failed to build playwright-ts image: %w", err)
 	}
 
@@ -589,7 +589,7 @@ func (o *testIntegrationOpts) buildDockerImages(ctx context.Context, project *me
 	pwNetParams := commonParams
 	pwNetParams.imageName = pwNetImage
 	pwNetParams.target = "playwright-net-tests"
-	if err := buildDockerImage(ctx,pwNetParams); err != nil {
+	if err := buildDockerImage(ctx, pwNetParams); err != nil {
 		return fmt.Errorf("failed to build playwright-net image: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -16,16 +16,21 @@ import (
 
 func main() {
 	// Create a context that cancels on SIGINT (Ctrl+C) or SIGTERM.
-	// After the first signal, Go restores default signal handling,
-	// so a second Ctrl+C will terminate the process immediately.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Notify the user that graceful shutdown is in progress after Ctrl+C.
-	// The returned function unregisters the callback; we defer it so it runs
-	// before stop() (LIFO), preventing the message on normal exit.
+	// On the first signal: notify the user that graceful shutdown is in
+	// progress, then call stop() to unregister signal.Notify so a second
+	// Ctrl+C falls through to Go's default handler and terminates the
+	// process immediately. NotifyContext doesn't do this by itself — its
+	// goroutine consumes the first signal and exits, leaving subsequent
+	// signals to queue silently in the channel buffer.
+	//
+	// cancelMsg unregisters the callback on normal exit so we don't print
+	// the message when the command completes successfully.
 	cancelMsg := context.AfterFunc(ctx, func() {
 		fmt.Fprintln(os.Stderr, "\nInterrupted, cleaning up... (press Ctrl+C again to force quit)")
+		stop()
 	})
 	defer cancelMsg()
 


### PR DESCRIPTION
## Summary
Follow-ups to PLA-1205 (#148) addressing several rough edges in Ctrl+C handling:

- **Force-kill `cmd.exe` shims immediately on cancel.** When `pnpm.cmd`/`playwright.cmd` runs through `cmd.exe`, Ctrl+C makes `cmd.exe` show `Terminate batch job (Y/N)?` and block until the WaitDelay timer force-kills it. We now route the Cancel callback for `.cmd`/`.bat` invocations through the Job Object handle, so the kernel terminates `cmd.exe` before it can write the prompt. Native executables (`dotnet`, `docker`) keep the graceful no-op Cancel + 10s WaitDelay path.
- **Graceful shutdown by default.** `executeCommand`, `execChildTask`, and `execChildInteractive` now override `exec.CommandContext`'s default `Process.Kill` Cancel with a no-op + WaitDelay so the child has a window to handle its own Ctrl+C — docker can forward SIGTERM to `--rm` containers, dotnet can flush state.
- **Close the Windows Job Object spawn race.** The child is now started `CREATE_SUSPENDED`, attached to the job, then resumed via thread enumeration. Descendants spawned by the child inherit the job automatically — no more orphan window between `cmd.Start` and `AssignProcessToJobObject`.
- **Second Ctrl+C actually force-quits.** `signal.NotifyContext` leaves the channel registered after the first signal, so further signals just buffer silently. `main.go`'s "Interrupted, cleaning up..." `AfterFunc` now also calls `stop()` to unregister, letting Go's default handler kill the process on the second Ctrl+C.
- **Reliable signal-kill detection.** Replaced the ambiguous `ExitCode == -1` heuristic with `syscall.WaitStatus.Signaled()` on Unix; Windows still relies on the forwarded-signal tracker.
- **Clean error messages.** `execChildTask` no longer always says "failed to build the project" — `dotnet test` and `playwright install` failures now identify themselves correctly. A muted `Canceled.` trailing line is printed on Ctrl+C so docker's `ERROR: failed to solve: Canceled: context canceled` isn't the last thing on screen.
- **gofmt fix-ups** for `test_integration.go` and `process_tree_other.go` from #148.

## Test plan
- [x] `metaplay dev dashboard`, Ctrl+C: no `Terminate batch job (Y/N)?` prompt visible
- [x] `metaplay build dash`, Ctrl+C: prompt returns promptly, no orphan node processes
- [x] `metaplay build image`, Ctrl+C: docker build cancels cleanly, no orphan containers; trailing `Canceled.` line shown
- [x] `metaplay dev image`, Ctrl+C: `--rm` container actually stops (check `docker ps`)
- [x] `metaplay dev server`, Ctrl+C: dotnet shuts down gracefully (not SIGKILL'd)
- [x] Press Ctrl+C twice during a wedged child → process exits immediately on the second one
- [x] On Linux: same flows via `metaplay dev` work without regressions
- [x] CI: `go test ./...` passes, cross-compile clean on linux/darwin/windows