### PR TITLE
Fix Ctrl+C review findings: race, OOM misclassification, verbose noise

### DIFF
--- a/cmd/build_image.go
+++ b/cmd/build_image.go
@@ -342,18 +342,13 @@ func executeCommand(ctx context.Context, workingDir string, env []string, comman
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = workingDir
-	// On ctx cancellation, don't immediately TerminateProcess/SIGKILL the
-	// child — the OS already delivers Ctrl+C to the whole foreground process
-	// group (Unix) or console-attached processes (Windows). docker CLI needs
-	// that window to forward SIGTERM to its own descendants (a --rm
-	// container) and to drain its daemon-side build cancel. applyCancelPolicy
-	// installs a no-op Cancel + 10 s WaitDelay safety net.
-	setCleanup := applyCancelPolicy(cmd)
+	// startCmd installs a no-op Cancel + 10s WaitDelay so docker CLI can
+	// forward SIGTERM to its --rm container and drain a daemon-side build
+	// cancel before being force-killed.
 	cleanup, err := startCmd(cmd)
 	if err != nil {
 		return err
 	}
-	setCleanup(cleanup)
 	defer cleanup()
 	return cmd.Wait()
 }

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/hashicorp/go-version"
 	clierrors "github.com/metaplay/cli/internal/errors"
@@ -34,58 +33,6 @@ type SignaledError struct {
 
 func (e *SignaledError) Error() string { return e.Err.Error() }
 func (e *SignaledError) Unwrap() error { return e.Err }
-
-// isCmdShim reports whether cmd.Path resolves to a Windows .cmd or .bat
-// script. exec.Cmd invokes those via cmd.exe, which shows
-// "Terminate batch job (Y/N)?" on Ctrl+C and blocks until answered —
-// callers use this to opt into a faster Cancel policy (kill the whole
-// process tree atomically) instead of giving the child a graceful window.
-func isCmdShim(path string) bool {
-	if runtime.GOOS != "windows" {
-		return false
-	}
-	p := strings.ToLower(path)
-	return strings.HasSuffix(p, ".cmd") || strings.HasSuffix(p, ".bat")
-}
-
-// applyCancelPolicy configures cmd.Cancel and cmd.WaitDelay for graceful
-// vs. fast shutdown when ctx is canceled. It returns a setter the caller
-// must invoke after startCmd to wire the Job-Object cleanup into Cancel.
-//
-//   - .cmd/.bat shims (pnpm.cmd, playwright.cmd …): close the Job Object
-//     immediately on cancel. Otherwise cmd.exe would prompt
-//     "Terminate batch job (Y/N)?" and block until WaitDelay force-kills
-//     it. WaitDelay stays as a small safety net.
-//   - native executables (dotnet, docker, …): no-op Cancel + 10 s
-//     WaitDelay. The child handles its own SIGINT/CTRL_C_EVENT
-//     (forwarding to containers, flushing build state, etc.); we only
-//     force-kill if it wedges.
-func applyCancelPolicy(cmd *exec.Cmd) func(cleanup func()) {
-	var (
-		mu      sync.Mutex
-		cleanup func()
-	)
-	if isCmdShim(cmd.Path) {
-		cmd.Cancel = func() error {
-			mu.Lock()
-			c := cleanup
-			mu.Unlock()
-			if c != nil {
-				c()
-			}
-			return nil
-		}
-		cmd.WaitDelay = 2 * time.Second
-	} else {
-		cmd.Cancel = func() error { return nil }
-		cmd.WaitDelay = 10 * time.Second
-	}
-	return func(c func()) {
-		mu.Lock()
-		cleanup = c
-		mu.Unlock()
-	}
-}
 
 // Environment variables to pass to all dotnet commands.
 var commonDotnetEnvVars = []string{
@@ -174,14 +121,12 @@ func execChildTask(ctx context.Context, workingDir string, binary string, args [
 	cmd.Dir = workingDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCleanup := applyCancelPolicy(cmd)
 
 	log.Info().Msg(styles.RenderMuted(fmt.Sprintf("%s$ %s %s", workingDir, binary, strings.Join(args, " "))))
 	cleanup, err := startCmd(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to start %s: %w", binary, err)
 	}
-	setCleanup(cleanup)
 	defer cleanup()
 	if err := cmd.Wait(); err != nil {
 		return fmt.Errorf("%s exited with error: %w", binary, err)
@@ -218,11 +163,9 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 	// We forward signals to the child manually (see goroutine below) and
 	// also rely on OS-level signal delivery (process group on Unix, console
 	// attachment on Windows). exec.CommandContext's default Cancel is
-	// Process.Kill — that would race ahead of our graceful signal and
-	// SIGKILL/TerminateProcess the child mid-shutdown. applyCancelPolicy
-	// installs a no-op (or, for .cmd/.bat shims on Windows, a Job-Object-
-	// closing) Cancel along with a WaitDelay safety net.
-	setCleanup := applyCancelPolicy(cmd)
+	// Process.Kill — startCmd installs a gentler policy (no-op Cancel for
+	// native executables; immediate Job-Object close for .cmd/.bat shims)
+	// along with a WaitDelay safety net.
 
 	// Create a channel to forward signals to the subprocess. Track whether
 	// we forwarded one so we can mark the resulting error as signal-induced
@@ -250,7 +193,6 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 	if err != nil {
 		return fmt.Errorf("failed to start %s: %w", binary, err)
 	}
-	setCleanup(cleanup)
 	defer cleanup()
 
 	// Goroutine to forward signals to the subprocess. Exits when signalChan is closed.
@@ -277,13 +219,11 @@ func execChildInteractive(ctx context.Context, workingDir string, binary string,
 	sig := forwardedSig
 	mu.Unlock()
 
-	// On Unix, syscall.WaitStatus.Signaled() reports signal-induced exit
-	// reliably (unlike ExitCode == -1, which also fires for processes that
-	// haven't exited). Windows can't distinguish via ProcessState, so we
-	// fall back to whether we forwarded a signal ourselves.
-	killedBySignal := sig != nil || wasKilledBySignal(cmd.ProcessState)
-
-	if killedBySignal {
+	// Only tag the failure as signal-induced if WE forwarded the signal —
+	// inferring signal-kill from ProcessState would also fire for external
+	// SIGKILL (e.g. the Linux OOM killer or `kill -9 <pid>`) and silently
+	// suppress those errors via wasInterrupted's SignaledError check.
+	if sig != nil {
 		return &SignaledError{Signal: sig, Err: wrapped}
 	}
 	return wrapped

--- a/cmd/process_tree_other.go
+++ b/cmd/process_tree_other.go
@@ -7,34 +7,27 @@
 package cmd
 
 import (
-	"os"
 	"os/exec"
-	"syscall"
+	"time"
 )
 
-// startCmd starts the command and returns a cleanup function that callers
-// should defer. On Unix it's a thin wrapper over cmd.Start — process group
-// + SIGTERM/SIGKILL naturally tear down descendants. The Windows variant
+// startCmd configures cmd.Cancel/WaitDelay for graceful shutdown, starts
+// the command, and returns a cleanup function that callers should defer.
+// On Unix it's a thin wrapper over cmd.Start — process group +
+// SIGTERM/SIGKILL naturally tear down descendants. The Windows variant
 // goes through a job-object dance to atomically kill the whole subprocess
 // tree on cancellation.
+//
+// We replace exec.CommandContext's default Cancel (Process.Kill, which is
+// SIGKILL on Unix / TerminateProcess on Windows) with a no-op so the
+// OS-delivered Ctrl+C — already broadcast to every process in the
+// foreground process group — can drive a graceful shutdown. WaitDelay
+// caps the grace window with a force-kill if the child wedges.
 func startCmd(cmd *exec.Cmd) (func(), error) {
+	cmd.Cancel = func() error { return nil }
+	cmd.WaitDelay = 10 * time.Second
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
 	return func() {}, nil
-}
-
-// wasKilledBySignal reports whether the process was terminated by a signal
-// rather than exiting normally. Relies on syscall.WaitStatus.Signaled() —
-// more reliable than checking ExitCode == -1, which also fires for processes
-// that haven't yet exited.
-func wasKilledBySignal(ps *os.ProcessState) bool {
-	if ps == nil {
-		return false
-	}
-	ws, ok := ps.Sys().(syscall.WaitStatus)
-	if !ok {
-		return false
-	}
-	return ws.Signaled()
 }

--- a/cmd/process_tree_windows.go
+++ b/cmd/process_tree_windows.go
@@ -7,43 +7,86 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows"
 )
 
-// startCmd starts cmd inside a Windows Job Object so that closing the
-// returned cleanup func (or letting our process die) atomically terminates
-// the child and every descendant.
+// isCmdShim reports whether path resolves to a Windows .cmd or .bat script.
+// exec.Cmd invokes those via cmd.exe, which shows
+// "Terminate batch job (Y/N)?" on Ctrl+C and blocks until answered —
+// startCmd uses this to opt into a faster Cancel policy (kill the whole
+// process tree atomically) instead of giving the child a graceful window.
+func isCmdShim(path string) bool {
+	p := strings.ToLower(path)
+	return strings.HasSuffix(p, ".cmd") || strings.HasSuffix(p, ".bat")
+}
+
+// startCmd configures cmd.Cancel/WaitDelay, starts cmd inside a Windows
+// Job Object, and returns a cleanup function. Closing the cleanup func
+// (or letting our process die) atomically terminates the child and every
+// descendant via JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.
 //
 // To win the race against descendants spawning before we can put the child
-// in the job, we create the process with CREATE_SUSPENDED, attach it to
-// the job, and only then resume its main thread. Any process spawned by
-// the child after that point inherits the job automatically.
+// in the job, the process is created with CREATE_SUSPENDED, attached to
+// the job, and only then resumed. Anything the child spawns after that
+// inherits the job automatically.
 //
 // This matters because tools like pnpm/npm are installed as .cmd shims:
 // `exec.Command("pnpm", ...)` actually launches cmd.exe to run pnpm.cmd,
 // which spawns node.exe, which spawns its own worker processes. CTRL_C_EVENT
-// propagation across that chain is unreliable — the immediate cmd.exe may
-// catch the signal and prompt "Terminate batch job (Y/N)?" while the node
-// descendants stay alive as orphans. With the job object, killing the parent
-// reliably tears down the whole tree.
+// propagation across that chain is unreliable — cmd.exe catches the signal
+// and shows "Terminate batch job (Y/N)?" while node descendants stay alive.
+// With the job object, killing the parent reliably tears down the whole tree.
+//
+// cmd.Cancel and cmd.WaitDelay are configured here (rather than by callers)
+// so the Cancel closure captures the cleanup func directly — no indirection
+// variable, no race window between cmd.Start and a post-hoc setCleanup.
 func startCmd(cmd *exec.Cmd) (func(), error) {
 	job, jobErr := prepareJob()
+
+	// cleanup is referenced by cmd.Cancel below, so it must be in scope
+	// before cmd.Start (which spawns exec.Cmd's ctx-watching goroutine).
+	// sync.Once makes it safe to invoke from both Cancel and a deferred
+	// caller path without double-closing a recycled handle.
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			if jobErr == nil {
+				_ = windows.CloseHandle(job)
+			}
+		})
+	}
+
+	// For .cmd/.bat shims (pnpm.cmd, playwright.cmd, ...): close the Job
+	// Object immediately on cancel so cmd.exe is killed before it can write
+	// "Terminate batch job (Y/N)?" to the console. For native executables
+	// (dotnet, docker): no-op Cancel + a 10s WaitDelay so the child can
+	// handle its own SIGINT/CTRL_C_EVENT (forwarding to containers, flushing
+	// build state, etc.) before being force-killed.
+	if isCmdShim(cmd.Path) {
+		cmd.Cancel = func() error { cleanup(); return nil }
+		cmd.WaitDelay = 2 * time.Second
+	} else {
+		cmd.Cancel = func() error { return nil }
+		cmd.WaitDelay = 10 * time.Second
+	}
+
 	if jobErr != nil {
-		// Job setup failed; degrade gracefully to a plain Start. Descendants
-		// will outlive cancellation, but we don't want job-object problems
+		// Job setup failed; fall through to a plain Start. Descendants
+		// may outlive cancellation, but we don't want job-object problems
 		// to break the build.
 		log.Debug().Err(jobErr).Msg("Job object setup failed; subprocess tree may outlive cancellation")
 		if err := cmd.Start(); err != nil {
 			return nil, err
 		}
-		return func() {}, nil
+		return cleanup, nil
 	}
 
 	// Create the child suspended so we can attach it to the job before it
@@ -54,7 +97,7 @@ func startCmd(cmd *exec.Cmd) (func(), error) {
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
 
 	if err := cmd.Start(); err != nil {
-		_ = windows.CloseHandle(job)
+		cleanup()
 		return nil, err
 	}
 
@@ -63,29 +106,27 @@ func startCmd(cmd *exec.Cmd) (func(), error) {
 
 	// We MUST resume the thread no matter what — leaving it suspended hangs
 	// cmd.Wait forever. If we couldn't assign to the job, the cleanup func
-	// becomes a no-op, but the process still runs to completion.
+	// stays a job-closer but the process runs outside the job.
 	if err := resumeProcessThreads(pid); err != nil {
 		// Truly stuck: process is suspended and we can't unstick it. Best
 		// effort is to kill it and Wait so exec.Cmd's internal watchdog
-		// goroutine exits (cmd.Wait signals ctxDone; without it the
-		// goroutine lives until ctx.Done fires).
+		// goroutine exits.
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
-		_ = windows.CloseHandle(job)
+		cleanup()
 		return nil, fmt.Errorf("failed to resume suspended child (pid %d): %w", pid, err)
 	}
 
 	if assignErr != nil {
 		log.Debug().Err(assignErr).Uint32("pid", pid).Msg("AssignProcessToJobObject failed; subprocess tree may outlive cancellation")
-		_ = windows.CloseHandle(job)
+		// Close the orphaned job. cmd.Cancel still references our cleanup
+		// closure — since the process isn't in the job, the Cancel hook
+		// degrades to a no-op (sync.Once swallows the second close).
+		cleanup()
 		return func() {}, nil
 	}
 
-	// Wrap CloseHandle in sync.Once so callers can invoke cleanup more than
-	// once (e.g. from both cmd.Cancel and a deferred call) without risking
-	// a double-close on a recycled handle.
-	var once sync.Once
-	return func() { once.Do(func() { _ = windows.CloseHandle(job) }) }, nil
+	return cleanup, nil
 }
 
 // prepareJob creates a Job Object configured to terminate every process in
@@ -171,12 +212,4 @@ func resumeProcessThreads(pid uint32) error {
 		return fmt.Errorf("no threads found for pid %d", pid)
 	}
 	return nil
-}
-
-// wasKilledBySignal: Windows doesn't surface signal-induced termination via
-// ProcessState (TerminateProcess sets an arbitrary exit code, and even
-// Ctrl+C handlers may set their own). Callers must track forwarded signals
-// themselves; this helper exists for cross-platform symmetry.
-func wasKilledBySignal(_ *os.ProcessState) bool {
-	return false
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -408,9 +408,13 @@ func wasInterrupted(cmd *cobra.Command, err error) bool {
 // closure after subprocess output — e.g. docker prints
 // "ERROR: failed to build: failed to solve: Canceled: context canceled"
 // on its way out and that shouldn't be the last thing the user sees.
+//
+// We write directly to os.Stderr rather than through stderrLogger so
+// verbose mode doesn't decorate the trailing line with timestamp and
+// level prefixes.
 func exitInterrupted() {
-	stderrLogger.Info().Msg("")
-	stderrLogger.Info().Msg(styles.RenderMuted("Canceled."))
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, styles.RenderMuted("Canceled."))
 	os.Exit(130)
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #150 addressing review findings:

- **Close the `startCmd` → `setCleanup` race.** The Cancel/WaitDelay policy decision (and the Job-Object cleanup closure on Windows) now lives inside `startCmd`, so `cmd.Cancel` captures the cleanup closure directly — no indirection variable, no window where exec.Cmd's ctx-watching goroutine fires Cancel before `cleanup` is wired in. `applyCancelPolicy` is removed; the three callers now just `cleanup, err := startCmd(cmd)`.
- **Stop misclassifying external SIGKILL as user cancel.** The `wasKilledBySignal`-based `SignaledError` tagging fired for OOM kills, external `kill -9`, etc. Those were then absorbed by `wasInterrupted`'s third clause and surfaced as a misleading muted `Canceled.` line with no diagnostic. Only signals **we forwarded** (`sig != nil`) now produce a `SignaledError`; everything else surfaces as a real error. The `wasKilledBySignal` helpers are removed since nothing else used them.
- **Fix verbose-mode rendering of `Canceled.`.** Routing it through `stderrLogger` meant verbose mode decorated it with timestamp+level prefixes — the intended blank separator turned into `2026-05-26 14:23:00.123 INF ` and the message became another technical-looking timestamped line. `exitInterrupted` now writes directly to `os.Stderr` so the trailing line stays clean in both default and `--verbose` modes.

## Test plan
- [x] `go build ./... && GOOS=windows go build ./... && GOOS=linux go build ./... && GOOS=darwin go build ./...` — all clean
- [x] `go test ./...` — passes
- [x] `gofmt -l` clean on touched files
- [ ] `metaplay build dash`, Ctrl+C as pnpm starts: cmd.exe prompt does NOT appear (race window closed)
- [ ] `metaplay build image`, Ctrl+C: trailing line reads `Canceled.` (no timestamp prefix even with `--verbose`)
- [ ] External `kill -9` on a child during a build: real error surfaces (not absorbed as `Canceled.`)