### PR TITLE
Rename sub-skill addresses from slash to dash form

### DIFF
--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -34,7 +34,7 @@ var skillsCmd = &cobra.Command{
 		'metaplay skills install'.
 
 		Sub-skills of a skill are not written to disk — they stay in the CLI
-		and are fetched on demand via 'metaplay skills get <skill>/<sub-skill>'.
+		and are fetched on demand via 'metaplay skills get <skill>-<sub-skill>'.
 	`),
 	Example: renderExample(`
 		# List the skills shipped with this CLI.
@@ -47,7 +47,7 @@ var skillsCmd = &cobra.Command{
 		metaplay skills get metaplay-develop
 
 		# Print a sub-skill.
-		metaplay skills get metaplay-develop/review-models
+		metaplay skills get metaplay-develop-review-models
 
 		# Install the wrappers into the current project for Claude Code.
 		metaplay skills install

--- a/cmd/skills_get.go
+++ b/cmd/skills_get.go
@@ -23,7 +23,7 @@ func init() {
 	o := skillsGetOpts{}
 
 	args := o.Arguments()
-	args.AddStringArgument(&o.argName, "NAME", "Skill or sub-skill address (e.g., 'metaplay-develop' or 'metaplay-develop/review-models').")
+	args.AddStringArgument(&o.argName, "NAME", "Skill or sub-skill address (e.g., 'metaplay-develop' or 'metaplay-develop-review-models').")
 
 	cmd := &cobra.Command{
 		Use:   "get NAME",
@@ -37,7 +37,7 @@ func init() {
 			{Arguments}
 
 			NAME is either a skill name (returns its SKILL.md) or
-			'<skill>/<sub-skill>' (returns a sub-skill).
+			'<skill>-<sub-skill>' (returns a sub-skill).
 
 			Output goes to stdout with a single trailing newline so it can
 			be piped or captured by an AI agent.
@@ -47,7 +47,7 @@ func init() {
 			metaplay skills get metaplay-develop
 
 			# Print the review-models sub-skill.
-			metaplay skills get metaplay-develop/review-models
+			metaplay skills get metaplay-develop-review-models
 		`),
 	}
 
@@ -85,10 +85,8 @@ func (o *skillsGetOpts) Run(cmd *cobra.Command) error {
 
 	// Root address: substitute the {{subskills}} marker (if present) with an
 	// auto-rendered sub-skills section. Sub-skill reads pass through verbatim.
-	if !strings.Contains(o.argName, "/") {
-		if skill := skillspkg.FindByID(skills, o.argName); skill != nil {
-			content = skillspkg.RenderRootPage(skill, content)
-		}
+	if skill := skillspkg.FindByID(skills, o.argName); skill != nil {
+		content = skillspkg.RenderRootPage(skill, content)
 	}
 
 	printSkillContent(content)

--- a/cmd/skills_list.go
+++ b/cmd/skills_list.go
@@ -34,7 +34,7 @@ func init() {
 
 			By default only top-level skills are listed. Pass --full to also
 			list each skill's sub-skills after their parent in DFS order, with
-			their full '<skill>/<sub-skill>' address (the same form
+			their full '<skill>-<sub-skill>' address (the same form
 			'metaplay skills get' accepts) and the description from the
 			sub-skill's own frontmatter.
 		`),
@@ -76,7 +76,7 @@ func (o *skillsListOpts) Run(cmd *cobra.Command) error {
 			if subDesc == "" {
 				subDesc = styles.RenderMuted("(no description)")
 			}
-			fmt.Printf("  %s: %s\n", styles.RenderSuccess(s.ID+"/"+p), subDesc)
+			fmt.Printf("  %s: %s\n", styles.RenderSuccess(s.ID+"-"+p), subDesc)
 		}
 	}
 	return nil

--- a/cmd/skills_try.go
+++ b/cmd/skills_try.go
@@ -69,7 +69,7 @@ func (o *skillsTryOpts) Run(cmd *cobra.Command) error {
 	fmt.Println()
 	fmt.Println("If the main page references sub-skills relevant to the task, load those too:")
 	fmt.Println()
-	fmt.Println("  metaplay skills get <skill>/<sub-skill>")
+	fmt.Println("  metaplay skills get <skill>-<sub-skill>")
 	fmt.Println()
 	fmt.Println("Available skills:")
 

--- a/pkg/skills/data/metaplay-develop/init-dashboard.md
+++ b/pkg/skills/data/metaplay-develop/init-dashboard.md
@@ -39,7 +39,7 @@ No flags; it's a one-shot setup. The command is idempotent only in the loose sen
 
 ## Prerequisites
 
-- `metaplay-project.yaml` exists (the project is initialized — see `metaplay-develop/init-project` if not).
+- `metaplay-project.yaml` exists (the project is initialized — see `metaplay-develop-init-project` if not).
 - Node.js and `pnpm` are installed and meet the version requirements the SDK declares. The command will fail with a clear error if not.
 - No existing `Backend/Dashboard/` directory (or you accept it being clobbered).
 
@@ -65,7 +65,7 @@ metaplay build dashboard --output-prebuilt
 # Commit Backend/PrebuiltDashboard/ to version control.
 ```
 
-See `metaplay-develop/local-development` for the broader local-dev loop.
+See `metaplay-develop-local-development` for the broader local-dev loop.
 
 ## Troubleshooting
 
@@ -77,11 +77,11 @@ metaplay dev clean-dashboard-artifacts
 
 This clears the Vite/pnpm caches under `Backend/Dashboard/`. Re-run `metaplay build dashboard` or `metaplay dev dashboard` afterward.
 
-If the SDK has been updated and dashboard build starts failing, that's usually a peer-dependency drift — `metaplay update sdk` walks the SDK release-notes migration guide for changes that affect the dashboard. See `metaplay-develop/update-sdk`.
+If the SDK has been updated and dashboard build starts failing, that's usually a peer-dependency drift — `metaplay update sdk` walks the SDK release-notes migration guide for changes that affect the dashboard. See `metaplay-develop-update-sdk`.
 
 ## Error patterns
 
 - **`Backend/Dashboard already exists`:** the dashboard is already scaffolded. Either delete the directory and re-init (destructive — confirm with the user), or skip the init and go straight to `metaplay dev dashboard`.
 - **`pnpm-workspace.yaml already exists`:** same situation; the user has already done this.
 - **Node / pnpm version too old:** install the required versions; the SDK pins these and the command's error names the minimum.
-- **`metaplay-project.yaml not found`:** run `metaplay init project` (or `metaplay init project-config`) first — see `metaplay-develop/init-project`.
+- **`metaplay-project.yaml not found`:** run `metaplay init project` (or `metaplay init project-config`) first — see `metaplay-develop-init-project`.

--- a/pkg/skills/data/metaplay-develop/init-project.md
+++ b/pkg/skills/data/metaplay-develop/init-project.md
@@ -90,8 +90,8 @@ The command shows a summary of detected paths and asks for confirmation before w
 Typical next steps:
 
 1. Open the Unity project; the SDK scaffold and HelloWorld scene are now part of the asset tree.
-2. Run the server locally: `metaplay dev server` (see `metaplay-develop/local-development`).
-3. Build the dashboard if customizing it: `metaplay init dashboard` (see `metaplay-develop/init-dashboard`).
+2. Run the server locally: `metaplay dev server` (see `metaplay-develop-local-development`).
+3. Build the dashboard if customizing it: `metaplay init dashboard` (see `metaplay-develop-init-dashboard`).
 4. Look at the generated `metaplay-project.yaml` — it lists the environments the project can deploy to.
 
 ## Common mistakes
@@ -103,6 +103,6 @@ Typical next steps:
 
 ## Related
 
-- After init: `metaplay-develop/local-development` to run the stack, and the parent `metaplay-develop` page's rule sub-skills (`review-actions`, `review-configs`, `review-models`) once code starts being written.
-- Updating the SDK in an already-initialized project: `metaplay-develop/update-sdk`.
-- Custom LiveOps Dashboard scaffolding: `metaplay-develop/init-dashboard`.
+- After init: `metaplay-develop-local-development` to run the stack, and the parent `metaplay-develop` page's rule sub-skills (`review-actions`, `review-configs`, `review-models`) once code starts being written.
+- Updating the SDK in an already-initialized project: `metaplay-develop-update-sdk`.
+- Custom LiveOps Dashboard scaffolding: `metaplay-develop-init-dashboard`.

--- a/pkg/skills/data/metaplay-develop/local-development.md
+++ b/pkg/skills/data/metaplay-develop/local-development.md
@@ -91,4 +91,4 @@ That clears the Vite/pnpm caches under `Backend/Dashboard/`. Re-run the build/de
 - **`.NET SDK not found / wrong version`:** `metaplay dev server` validates the .NET SDK on each run. Install per the error's suggested URL.
 - **`port already in use`:** another local process holds the port. Find and kill it, or change the port via the relevant `Options.*.yaml`.
 - **Dashboard build fails with `pnpm`/`node` complaints:** `metaplay dev clean-dashboard-artifacts`, then rebuild.
-- **`MetaplaySDK/` not found:** the project hasn't been initialized. See `metaplay-develop/init-project`.
+- **`MetaplaySDK/` not found:** the project hasn't been initialized. See `metaplay-develop-init-project`.

--- a/pkg/skills/data/metaplay-devops/cpu-profiling.md
+++ b/pkg/skills/data/metaplay-devops/cpu-profiling.md
@@ -56,8 +56,8 @@ Longer captures produce much bigger files and slow down the post-processing. Don
 
 A flamegraph in speedscope is the canonical first view: wide bars at the top of the stack = the methods burning CPU. Cross-reference hot frames against:
 
-- `metaplay-develop/review-actions` rule **PS1** (performance on frequently-invoked actions).
-- `metaplay-develop/review-models` rules **GT1**/**GT3** (GameTick performance, per-tick work).
+- `metaplay-develop-review-actions` rule **PS1** (performance on frequently-invoked actions).
+- `metaplay-develop-review-models` rules **GT1**/**GT3** (GameTick performance, per-tick work).
 - The `metaplay-develop` rule **D3** (avoid `SortedSet`/`SortedDictionary`) — sorted-collection hot frames are a common false positive that's actually a real issue.
 
 If the hot path is inside SDK code (e.g. serialization, scheduler), it's usually a downstream symptom of a userland mistake — back up the stack until you find the userland frame that called it.

--- a/pkg/skills/data/metaplay-devops/deploy-server.md
+++ b/pkg/skills/data/metaplay-devops/deploy-server.md
@@ -48,7 +48,7 @@ metaplay get server-info <env>           # Helm release, image, replicas, etc.
 metaplay debug server-status <env>       # Re-run the health checks any time.
 ```
 
-If verification fails, jump to `metaplay-devops/diagnose-server` (and `metaplay-devops/view-logs` for the actual error).
+If verification fails, jump to `metaplay-devops-diagnose-server` (and `metaplay-devops-view-logs` for the actual error).
 
 ## Rolling back
 
@@ -82,5 +82,5 @@ If the user is fighting Helm-level issues, `--dry-run` plus the relevant overrid
 - **`401` / authentication:** session expired — `metaplay auth login`.
 - **`403` / permission denied:** user lacks the `api.deployments.write` permission for that environment.
 - **Image not found in registry:** the tag wasn't pushed. Either pass `mygame:<tag>` to `deploy server` (auto-push), or `metaplay image push <env> mygame:<tag>` first.
-- **Health checks fail after deploy:** the deploy itself probably succeeded but the server didn't come up cleanly. Go to `metaplay-devops/diagnose-server`.
+- **Health checks fail after deploy:** the deploy itself probably succeeded but the server didn't come up cleanly. Go to `metaplay-devops-diagnose-server`.
 - **Helm-level error (chart not found, release exists, etc.):** rerun with `--dry-run` to inspect what's being applied; the error message names the offending resource.

--- a/pkg/skills/data/metaplay-devops/diagnose-server.md
+++ b/pkg/skills/data/metaplay-devops/diagnose-server.md
@@ -5,7 +5,7 @@ description: Diagnose a misbehaving Metaplay game server in a cloud environment 
 
 # Diagnose a running cloud server
 
-Whole-server triage. For a single player's incident report from the dashboard, use `metaplay-develop/incident-analysis` instead.
+Whole-server triage. For a single player's incident report from the dashboard, use `metaplay-develop-incident-analysis` instead.
 
 ## Symptom → first tool
 
@@ -13,9 +13,9 @@ Whole-server triage. For a single player's incident report from the dashboard, u
 |---|---|
 | Deploy reported health-check failures | `metaplay debug server-status <env>` to re-run and read the failure detail; then `metaplay debug logs <env>` for the actual error. |
 | Site is down or unreachable | `metaplay debug server-status <env>` — tells you which check failed (pod readiness vs DNS vs admin endpoint vs client endpoint). |
-| Server up but throwing errors | `metaplay debug logs <env> --since=15m` then filter for `ERR`/`Exception`. See `metaplay-devops/view-logs`. |
-| Latency spike, server slow | `metaplay debug collect-cpu-profile <env>` — see `metaplay-devops/cpu-profiling`. |
-| OOM, server memory growing | `metaplay debug collect-heap-dump <env>` — see `metaplay-devops/memory-profiling`. |
+| Server up but throwing errors | `metaplay debug logs <env> --since=15m` then filter for `ERR`/`Exception`. See `metaplay-devops-view-logs`. |
+| Latency spike, server slow | `metaplay debug collect-cpu-profile <env>` — see `metaplay-devops-cpu-profiling`. |
+| OOM, server memory growing | `metaplay debug collect-heap-dump <env>` — see `metaplay-devops-memory-profiling`. |
 | Pod crash-looping or stuck | `metaplay debug server-status` to confirm, then `metaplay debug logs <env> --pod <name>` for the dying pod's output. |
 | Suspect data issue (corrupt entity, missing row) | `metaplay debug database <env>` — read-only by default; pass `--read-write` deliberately. |
 | Need to poke around inside a pod | `metaplay debug shell <env> [pod]` — ephemeral debug container attached to the game server container. |
@@ -63,7 +63,7 @@ For server-wide observability data the admin API exposes (active connections, in
 metaplay debug admin-request <env> GET <api-path>
 ```
 
-Examples in `metaplay-develop/incident-analysis` (it uses `admin-request` to fetch per-player incidents).
+Examples in `metaplay-develop-incident-analysis` (it uses `admin-request` to fetch per-player incidents).
 
 ## Closing the loop
 
@@ -74,4 +74,4 @@ Once a symptom is narrowed down to a code-level bug (stack trace in logs, hot me
 - **`401` / auth:** `metaplay auth login`.
 - **`403` / permission denied:** user lacks the relevant per-env permission (e.g. `api.logs.view`, `api.shell.access`, `api.deployments.read`).
 - **`env not found`:** name doesn't match `metaplay-project.yaml`.
-- **`no pods found`:** the env has no running game server. `metaplay deploy server` first; see `metaplay-devops/deploy-server`.
+- **`no pods found`:** the env has no running game server. `metaplay deploy server` first; see `metaplay-devops-deploy-server`.

--- a/pkg/skills/data/metaplay-devops/main.md
+++ b/pkg/skills/data/metaplay-devops/main.md
@@ -2,7 +2,7 @@
 
 Operating a Metaplay game server in a cloud environment: building and pushing images, deploying and rolling back, checking status, pulling logs, capturing CPU and heap profiles for diagnosis, and managing per-environment Kubernetes secrets.
 
-This skill is about *what to run when something is wrong with — or about to change in — a deployed server*. For writing game code, use `metaplay-develop`. For per-player crash/desync reports surfaced in the dashboard, use `metaplay-develop/incident-analysis`. For the CLI itself misbehaving (missing, outdated, weird output), use `metaplay-troubleshoot`.
+This skill is about *what to run when something is wrong with — or about to change in — a deployed server*. For writing game code, use `metaplay-develop`. For per-player crash/desync reports surfaced in the dashboard, use `metaplay-develop-incident-analysis`. For the CLI itself misbehaving (missing, outdated, weird output), use `metaplay-troubleshoot`.
 
 ## Environments
 
@@ -25,6 +25,6 @@ The sub-skills are independent playbooks — load only what the current task nee
 ## When NOT to use this skill
 
 - Authoring or reviewing C# code, models, actions, or configs — use `metaplay-develop`.
-- Per-player crash, desync, or network incident reports from the dashboard — use `metaplay-develop/incident-analysis`.
+- Per-player crash, desync, or network incident reports from the dashboard — use `metaplay-develop-incident-analysis`.
 - The `metaplay` CLI itself is missing, outdated, or returns garbled output — use `metaplay-troubleshoot`.
 - SDK API or concept questions ("how does X work?") — use `metaplay-docs`.

--- a/pkg/skills/data/metaplay-devops/memory-profiling.md
+++ b/pkg/skills/data/metaplay-devops/memory-profiling.md
@@ -56,7 +56,7 @@ What to look for:
 
 - **Object counts by type** sorted by retained size — the top entries name the leaking class.
 - **`gcroot`** on a leaking instance — shows what's holding the reference (the actual leak path).
-- **Unbounded collections** — a `List<T>` / `MetaDictionary<>` with millions of entries is almost always a missing prune. Cross-reference `metaplay-develop/review-models` rule **MI1**.
+- **Unbounded collections** — a `List<T>` / `MetaDictionary<>` with millions of entries is almost always a missing prune. Cross-reference `metaplay-develop-review-models` rule **MI1**.
 
 ## Common leak shapes in Metaplay code
 

--- a/pkg/skills/embedded_test.go
+++ b/pkg/skills/embedded_test.go
@@ -106,7 +106,7 @@ func TestEmbedded_ResolveSkillRoot(t *testing.T) {
 
 func TestEmbedded_ResolveSubSkill(t *testing.T) {
 	loaded, _ := LoadAll(EmbeddedFS())
-	got, err := Resolve(loaded, "metaplay-develop/review-models")
+	got, err := Resolve(loaded, "metaplay-develop-review-models")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestEmbedded_ResolveUnknownSkill(t *testing.T) {
 
 func TestEmbedded_ResolveUnknownSubSkill(t *testing.T) {
 	loaded, _ := LoadAll(EmbeddedFS())
-	_, err := Resolve(loaded, "metaplay-develop/nonexistent")
+	_, err := Resolve(loaded, "metaplay-develop-nonexistent")
 	if !errors.Is(err, ErrSubSkillNotFound) {
 		t.Errorf("expected ErrSubSkillNotFound, got %v", err)
 	}

--- a/pkg/skills/example_test.go
+++ b/pkg/skills/example_test.go
@@ -60,7 +60,7 @@ func ExampleResolve() {
 	}
 	fmt.Printf("wrapper present: %v\n", len(wrapper) > 0)
 
-	subSkill, err := skills.Resolve(loaded, "metaplay-develop/review-models")
+	subSkill, err := skills.Resolve(loaded, "metaplay-develop-review-models")
 	if err != nil {
 		fmt.Println("sub-skill:", err)
 		return

--- a/pkg/skills/render.go
+++ b/pkg/skills/render.go
@@ -29,7 +29,7 @@ var (
 // RenderRootPage substitutes the {{subskills}} marker in a root page's content
 // with an auto-generated sub-skills section. The expansion includes the
 // `## Sub-skills` heading and a bullet list — one bullet per sub-skill, with
-// the full `metaplay skills get <skill>/<sub-skill>` address and the
+// the full `metaplay skills get <skill>-<sub-skill>` address and the
 // sub-skill's frontmatter description. The `main` entry (the root body
 // itself) is excluded.
 //
@@ -70,7 +70,7 @@ func buildSubSkillsSection(skill *Skill) string {
 		if desc == "" {
 			desc = "(no description)"
 		}
-		entries = append(entries, fmt.Sprintf("- `metaplay skills get %s/%s` — %s", skill.ID, p, desc))
+		entries = append(entries, fmt.Sprintf("- `metaplay skills get %s-%s` — %s", skill.ID, p, desc))
 	}
 	if len(entries) == 0 {
 		return ""

--- a/pkg/skills/render_test.go
+++ b/pkg/skills/render_test.go
@@ -58,19 +58,19 @@ func TestRenderRootPage_ExpandsWithSubSkills(t *testing.T) {
 		t.Errorf("missing section header in output: %q", got)
 	}
 	wantBullets := []string{
-		"- `metaplay skills get alpha/one` — First sub-skill.",
-		"- `metaplay skills get alpha/three` — Third sub-skill.",
-		"- `metaplay skills get alpha/two` — Second sub-skill.",
+		"- `metaplay skills get alpha-one` — First sub-skill.",
+		"- `metaplay skills get alpha-three` — Third sub-skill.",
+		"- `metaplay skills get alpha-two` — Second sub-skill.",
 	}
 	for _, b := range wantBullets {
 		if !strings.Contains(got, b) {
 			t.Errorf("missing bullet %q in output: %q", b, got)
 		}
 	}
-	if strings.Contains(got, "alpha/main") {
+	if strings.Contains(got, "alpha-main") {
 		t.Errorf("main should be excluded from sub-skills list, got %q", got)
 	}
-	if i := strings.Index(got, "alpha/one"); i < 0 || strings.Index(got, "alpha/three") < i {
+	if i := strings.Index(got, "alpha-one"); i < 0 || strings.Index(got, "alpha-three") < i {
 		t.Errorf("sub-skills should be sorted alphabetically: %q", got)
 	}
 }

--- a/pkg/skills/skill.go
+++ b/pkg/skills/skill.go
@@ -180,35 +180,38 @@ var ErrSkillNotFound = errors.New("skill not found")
 // skill but an unknown sub-skill within it.
 var ErrSubSkillNotFound = errors.New("sub-skill not found")
 
-// Resolve looks up content by an address of the form `<skill>` or
-// `<skill>/<sub-skill>`. The first form returns the skill's main payload —
-// `main.md` if present, else SKILL.md as a fallback. The second form
-// returns a sub-skill's bytes; the special name `SKILL.md` returns
-// the raw wrapper file (intended for internal/debug use, not advertised).
+// Resolve looks up content by a dash-separated address. The plain skill ID
+// (e.g. `metaplay-develop`) returns that skill's main payload — `main.md` if
+// present, else SKILL.md as a fallback. A sub-skill address is the skill ID
+// followed by `-` and the sub-skill name (e.g. `metaplay-develop-update-sdk`).
+// Skill IDs are matched longest-first so a future ID that is itself a prefix
+// of another resolves unambiguously.
 func Resolve(skills []*Skill, address string) ([]byte, error) {
-	skillID, subSkillID, hasSubSkill := strings.Cut(address, "/")
-	if skillID == "" {
+	if address == "" {
 		return nil, fmt.Errorf("empty skill address")
 	}
-	skill := FindByID(skills, skillID)
-	if skill == nil {
-		return nil, fmt.Errorf("%w: %s", ErrSkillNotFound, skillID)
-	}
-	if !hasSubSkill {
+	if skill := FindByID(skills, address); skill != nil {
 		if main, ok := skill.SubSkills["main"]; ok {
 			return main.Raw, nil
 		}
 		return skill.RawSKILL, nil
 	}
-	if subSkillID == "" {
-		return nil, fmt.Errorf("empty sub-skill name in address %q", address)
+	candidates := make([]*Skill, len(skills))
+	copy(candidates, skills)
+	sort.Slice(candidates, func(i, j int) bool {
+		return len(candidates[i].ID) > len(candidates[j].ID)
+	})
+	for _, skill := range candidates {
+		prefix := skill.ID + "-"
+		if !strings.HasPrefix(address, prefix) {
+			continue
+		}
+		subSkillID := address[len(prefix):]
+		sub, ok := skill.SubSkills[subSkillID]
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrSubSkillNotFound, address)
+		}
+		return sub.Raw, nil
 	}
-	if subSkillID == "SKILL.md" {
-		return skill.RawSKILL, nil
-	}
-	sub, ok := skill.SubSkills[subSkillID]
-	if !ok {
-		return nil, fmt.Errorf("%w: %s/%s", ErrSubSkillNotFound, skillID, subSkillID)
-	}
-	return sub.Raw, nil
+	return nil, fmt.Errorf("%w: %s", ErrSkillNotFound, address)
 }

--- a/pkg/skills/skill_test.go
+++ b/pkg/skills/skill_test.go
@@ -96,7 +96,7 @@ func TestResolve_SkillRoot(t *testing.T) {
 
 func TestResolve_SubSkill(t *testing.T) {
 	loaded, _ := LoadAll(fakeSkillFS())
-	got, err := Resolve(loaded, "alpha/extra")
+	got, err := Resolve(loaded, "alpha-extra")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestResolve_UnknownSkill(t *testing.T) {
 
 func TestResolve_UnknownSubSkill(t *testing.T) {
 	loaded, _ := LoadAll(fakeSkillFS())
-	_, err := Resolve(loaded, "alpha/nonexistent")
+	_, err := Resolve(loaded, "alpha-nonexistent")
 	if !errors.Is(err, ErrSubSkillNotFound) {
 		t.Errorf("expected ErrSubSkillNotFound, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- Sub-skills had two address forms: frontmatter `name` (`metaplay-develop-update-sdk`, dash-form because it's what the `Skill` tool sees) and CLI address (`metaplay-develop/update-sdk`, slash-form). The slash form was unusable when an agent needed to reference a sub-skill by its `Skill`-tool name from inside another skill's body.
- Unify on dash form across CLI input (`Resolve()` parser now matches the longest skill ID prefix), CLI display (`skills list --full`, `{{subskills}}` rendering), markdown cross-references in skill bodies, and tests. The slash form is no longer accepted — no back-compat alias. The internal-only `SKILL.md` suffix special case is dropped (unreachable in dash form).
- On-disk directory layout under `pkg/skills/data/` is unchanged — it's a filesystem detail, not an address.

## Test plan

- [x] `make test` passes (all 19 skills-package tests, including engine tests against synthetic `fstest.MapFS` data)
- [x] `make` builds cleanly
- [x] `metaplay skills list --full` shows dash-form bullets (`metaplay-develop-update-sdk`, etc.)
- [x] `metaplay skills get metaplay-develop` prints the root page; `{{subskills}}` bullets are dash-form
- [x] `metaplay skills get metaplay-develop-update-sdk` returns the sub-skill content
- [x] `metaplay skills get metaplay-develop/update-sdk` now fails with `Unknown skill` (slash form removed)
- [x] `go mod tidy` leaves the tree clean