### PR TITLE
Reject re-pushing an existing image tag with different content

### DIFF
--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -476,7 +476,8 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 	// If using local image, add task to push it.
 	if useLocalImage {
 		taskRunner.AddTask("Push docker image to environment repository", func(output *tui.TaskOutput) error {
-			return pushDockerImage(cmd.Context(), output, o.argImageNameTag, envDetails.Deployment.EcrRepo, dockerCredentials)
+			_, err := pushDockerImage(cmd.Context(), output, o.argImageNameTag, envDetails.Deployment.EcrRepo, dockerCredentials)
+			return err
 		})
 	}
 

--- a/cmd/image_push.go
+++ b/cmd/image_push.go
@@ -111,8 +111,11 @@ func (o *imagePushOpts) Run(cmd *cobra.Command) error {
 	taskRunner := tui.NewTaskRunner()
 
 	// Push the image to the remote repository.
+	imagePushed := false
 	taskRunner.AddTask("Push docker image to environment repository", func(output *tui.TaskOutput) error {
-		return pushDockerImage(cmd.Context(), output, o.argImageName, envDetails.Deployment.EcrRepo, dockerCredentials)
+		pushed, err := pushDockerImage(cmd.Context(), output, o.argImageName, envDetails.Deployment.EcrRepo, dockerCredentials)
+		imagePushed = pushed
+		return err
 	})
 
 	// Run the tasks.
@@ -121,7 +124,11 @@ func (o *imagePushOpts) Run(cmd *cobra.Command) error {
 	}
 
 	log.Info().Msg("")
-	log.Info().Msg(styles.RenderSuccess("✅ Successfully pushed image!"))
+	if imagePushed {
+		log.Info().Msg(styles.RenderSuccess("✅ Successfully pushed image!"))
+	} else {
+		log.Info().Msg(styles.RenderSuccess("✅ Image already present in repository; nothing to push."))
+	}
 	return nil
 }
 
@@ -144,30 +151,61 @@ func extractDockerImageTag(imageName string) (string, error) {
 	return srcImageParts[1], nil
 }
 
-// Push a docker image from the local repo to a remote one.
-// Output progress into the task output.
-func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dstRepoName string, dockerCredentials *envapi.DockerCredentials) error {
+// pushDockerImage pushes a local image from the local repo to the remote repository, writing
+// progress into the task output. The returned bool is true if an image was actually pushed, and
+// false if the push was skipped because the identical image was already present in the repository.
+func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dstRepoName string, dockerCredentials *envapi.DockerCredentials) (bool, error) {
 	// Create a Docker client
 	cli, err := envapi.NewDockerClient()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Extract tag from source image.
 	imageTag, err := extractDockerImageTag(imageName)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Resolve source and destination image names.
 	srcImageName := imageName
 	dstImageName := fmt.Sprintf("%s:%s", dstRepoName, imageTag)
 
+	// Check whether the tag already exists in the remote repository. Image tags must be unique
+	// per build: re-using a tag (e.g. 'latest', a bare commit SHA, or any tag that has already
+	// been pushed) means a deployed environment can't reliably resolve which artifact it's
+	// running. We therefore refuse to overwrite a tag that already holds a different image.
+	remoteDigests, exists, err := envapi.FetchRemoteDockerImageDigests(dockerCredentials, dstImageName)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		// Resolve the local image's ID so we can tell apart "same image, re-pushed" (a harmless
+		// no-op we can skip) from "different image, same tag" (a hard error). The local image ID is
+		// the config digest under the legacy image store and the manifest digest under the
+		// containerd image store, so accept a match against either remote digest.
+		localImage, err := envapi.ReadLocalDockerImageMetadata(srcImageName)
+		if err != nil {
+			return false, err
+		}
+
+		if localImage.ImageID == remoteDigests.ConfigDigest || localImage.ImageID == remoteDigests.ManifestDigest {
+			// Identical image already in the repository: nothing to do.
+			output.AppendLinef("Image %s is already present in the repository (identical digest), skipping push", dstImageName)
+			return false, nil
+		}
+
+		// Same tag, different image content: refuse to overwrite.
+		return false, clierrors.Newf("Image tag '%s' already exists in the environment's repository with different content", imageTag).
+			WithDetails("Re-using an image tag is not supported: each build must be pushed with a unique tag.").
+			WithSuggestion("Rebuild with a unique tag and push that. A '<timestamp>-<commit>' tag (e.g. '20260601-153000-1a27c25') is recommended; 'metaplay build image' without a tag generates one automatically.")
+	}
+
 	// If names don't match, tag the source image as the destination.
 	if srcImageName != dstImageName {
 		output.AppendLinef("Tagging image %s as %s", srcImageName, dstImageName)
 		if err := cli.ImageTag(ctx, srcImageName, dstImageName); err != nil {
-			return fmt.Errorf("failed to tag image: %w", err)
+			return false, fmt.Errorf("failed to tag image: %w", err)
 		}
 	}
 
@@ -180,7 +218,7 @@ func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dst
 	}
 	authConfigBytes, err := json.Marshal(authConfig)
 	if err != nil {
-		return fmt.Errorf("failed to marshal auth config: %w", err)
+		return false, fmt.Errorf("failed to marshal auth config: %w", err)
 	}
 
 	// Encode with base64
@@ -190,7 +228,7 @@ func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dst
 		RegistryAuth: authStr,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to push docker image: %w", err)
+		return false, fmt.Errorf("failed to push docker image: %w", err)
 	}
 	defer pushResponseReader.Close()
 
@@ -205,7 +243,7 @@ func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dst
 			if err == io.EOF {
 				break
 			}
-			return fmt.Errorf("failed to decode push response: %w", err)
+			return false, fmt.Errorf("failed to decode push response: %w", err)
 		}
 
 		// Track progress by ID to show the latest status for each layer
@@ -219,7 +257,7 @@ func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dst
 
 		// If progress has an error, return it
 		if progress.Error != nil {
-			return fmt.Errorf("error pushing image: %s", progress.Error.Message)
+			return false, fmt.Errorf("error pushing image: %s", progress.Error.Message)
 		}
 
 		// Update the output with current progress information (only in interactive mode).
@@ -228,7 +266,7 @@ func pushDockerImage(ctx context.Context, output *tui.TaskOutput, imageName, dst
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // updateDockerProgressOutput updates the task output with the current Docker push/pull progress information.

--- a/pkg/envapi/docker_util.go
+++ b/pkg/envapi/docker_util.go
@@ -6,7 +6,9 @@ package envapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,6 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	clierrors "github.com/metaplay/cli/internal/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -126,9 +129,10 @@ func NewDockerClient() (*client.Client, error) {
 
 	// For non-connection errors, or non-macOS systems, return the original error.
 	dockerSuggestion := "Start Docker Desktop"
-	if runtime.GOOS == "linux" {
+	switch runtime.GOOS {
+	case "linux":
 		dockerSuggestion = "Start Docker with 'sudo systemctl start docker', or ensure your user is in the 'docker' group"
-	} else if runtime.GOOS == "windows" {
+	case "windows":
 		dockerSuggestion = "Start Docker Desktop from the Start menu"
 	}
 	return nil, clierrors.Wrap(err, "Cannot connect to Docker").
@@ -160,6 +164,79 @@ func ReadLocalDockerImageMetadata(imageRefString string) (*MetaplayImageInfo, er
 	// Use the helper function to convert inspect data to MetaplayImageInfo
 	// Pass imageInspect.ID as imageID, imageRefString as repoTag, and parsedRef for its Identifier method.
 	return newMetaplayImageInfoFromInspect(imageInspect.ID, imageRefString, parsedRef, imageInspect)
+}
+
+// RemoteDockerImageDigests holds the two content digests that can identify a remote image. Which
+// one matches a local image's reported ID depends on the local Docker daemon's image store:
+// the legacy store reports the config digest as the image ID, while the containerd store reports
+// the manifest digest. Both are preserved across push/pull, so comparing a local ID against both
+// detects an identical already-pushed image regardless of the store backend.
+type RemoteDockerImageDigests struct {
+	ConfigDigest   string // Digest of the image config blob (the legacy image-store ID).
+	ManifestDigest string // Digest of the image manifest (the containerd image-store ID).
+}
+
+// FetchRemoteDockerImageDigests returns the config and manifest digests of the image at the given
+// reference in a remote Docker registry.
+//
+// The 'exists' return value is false (with a nil error) when no image exists at the reference.
+func FetchRemoteDockerImageDigests(creds *DockerCredentials, imageRef string) (digests *RemoteDockerImageDigests, exists bool, err error) {
+	log.Debug().Msgf("Fetch digests of remote container image: %s", imageRef)
+	if imageRef == "" {
+		return nil, false, fmt.Errorf("empty image reference")
+	}
+
+	// Create a registry authenticator using the provided credentials.
+	authenticator := authn.FromConfig(authn.AuthConfig{
+		Username: creds.Username,
+		Password: creds.Password,
+	})
+
+	// Parse the image reference (name + tag or digest).
+	ref, err := name.ParseReference(imageRef, name.WithDefaultRegistry(creds.RegistryURL))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse remote docker image reference '%s': %w", imageRef, err)
+	}
+
+	// Fetch the image descriptor. A 'not found' response means the tag is free.
+	desc, err := remote.Get(ref, remote.WithAuth(authenticator))
+	if err != nil {
+		if isRemoteImageNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to query remote docker image '%s': %w", imageRef, err)
+	}
+
+	// Resolve the image and read its config digest. The descriptor digest is the manifest digest.
+	img, err := desc.Image()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get remote docker image from descriptor '%s': %w", imageRef, err)
+	}
+	cfgName, err := img.ConfigName()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get config digest for remote docker image '%s': %w", imageRef, err)
+	}
+
+	return &RemoteDockerImageDigests{
+		ConfigDigest:   cfgName.String(),
+		ManifestDigest: desc.Digest.String(),
+	}, true, nil
+}
+
+// isRemoteImageNotFound reports whether err from a remote registry query indicates that no image
+// exists at the requested reference (as opposed to a transport/auth/other failure).
+func isRemoteImageNotFound(err error) bool {
+	if transportErr, ok := errors.AsType[*transport.Error](err); ok {
+		for _, code := range transportErr.Errors {
+			if code.Code == transport.ManifestUnknownErrorCode || code.Code == transport.NameUnknownErrorCode {
+				return true
+			}
+		}
+		if transportErr.StatusCode == http.StatusNotFound {
+			return true
+		}
+	}
+	return false
 }
 
 // FetchRemoteDockerImageMetadata retrieves the labels of an image in a remote Docker registry.

--- a/pkg/envapi/docker_util_test.go
+++ b/pkg/envapi/docker_util_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package envapi
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+func TestIsRemoteImageNotFound(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "manifest unknown error code",
+			err:  &transport.Error{Errors: []transport.Diagnostic{{Code: transport.ManifestUnknownErrorCode}}},
+			want: true,
+		},
+		{
+			name: "name unknown error code",
+			err:  &transport.Error{Errors: []transport.Diagnostic{{Code: transport.NameUnknownErrorCode}}},
+			want: true,
+		},
+		{
+			name: "404 status without diagnostic code",
+			err:  &transport.Error{StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "wrapped not-found transport error",
+			err:  fmt.Errorf("query failed: %w", &transport.Error{StatusCode: http.StatusNotFound}),
+			want: true,
+		},
+		{
+			name: "unauthorized is not a not-found",
+			err:  &transport.Error{StatusCode: http.StatusUnauthorized, Errors: []transport.Diagnostic{{Code: transport.UnauthorizedErrorCode}}},
+			want: false,
+		},
+		{
+			name: "non-transport error",
+			err:  fmt.Errorf("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRemoteImageNotFound(tc.err); got != tc.want {
+				t.Errorf("isRemoteImageNotFound() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Pushing a server image now checks the remote repository for the target tag first, instead of unconditionally pushing. This applies to both `metaplay image push` and the implicit push inside `metaplay deploy server`.

Behaviour when the tag already exists:

- **Identical image already present** → skip the push (no-op) and report it, rather than re-uploading or falsely claiming a push happened.
- **Tag exists with different content** → hard-fail with an actionable error pointing at unique `<timestamp>-<commit>` tags.
- **Tag free** → push as before.

## Why

Image tags must be unique per build. Re-using a tag (`latest`, a bare commit SHA, or any already-pushed tag) means a deployed environment can't reliably resolve which artifact it's actually running.

## How the identical-image check works

It compares the local image ID against **both** the remote config digest and the remote manifest digest. This is deliberate: `docker inspect` reports a different digest depending on the daemon's image store —

- **legacy store** → image ID is the **config** digest (matches `img.ConfigName()`)
- **containerd store** (now the Docker default) → image ID is the **manifest** digest (matches the remote descriptor digest)

Comparing against both makes the skip work regardless of the store backend. Matching either is safe — both are SHA-256 digests of this exact image, so a false positive would require a hash collision. If the digests don't match, the change fails safe (a clear error, never a silent overwrite).

## Testing

- `go build` / `go test ./...` / `go vet` / `go mod tidy` all clean.
- Added a unit test for the registry "not found" classification (`isRemoteImageNotFound`).
- The digest-comparison and remote-fetch paths are not unit-tested (they need a live daemon + registry), consistent with the rest of `pkg/envapi`.

## Notes / not covered

- Correct for the single-arch `build image --load` → daemon-push flow this CLI uses.
- No `--force` override: identical re-pushes are auto-skipped, so the only thing left to block is the genuinely-divergent case.
