### PR TITLE
Detect CLI updates via non-throttled GitHub endpoints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,7 +120,7 @@ var rootCmd = &cobra.Command{
 		// Check for new CLI version available.
 		isUpdateCliCmd := parentCmd != nil && parentCmd.Name() == "update" && cmd.Use == "cli"
 		if !skipAppVersionCheck && !isUpdateCliCmd {
-			version.CheckVersion(&stderrLogger)
+			version.CheckVersion(cmd.Context(), &stderrLogger)
 		}
 	},
 }

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -5,10 +5,7 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/creativeprojects/go-selfupdate"
+	clierrors "github.com/metaplay/cli/internal/errors"
 	"github.com/metaplay/cli/internal/pathutil"
 	"github.com/metaplay/cli/internal/version"
 	"github.com/metaplay/cli/pkg/styles"
@@ -38,18 +35,8 @@ func (o *updateCliOpts) Prepare(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type selfupdateLogger struct{}
-
-func (l selfupdateLogger) Print(v ...any) {
-	log.Debug().Msgf("%v", v...)
-}
-
-func (l selfupdateLogger) Printf(format string, v ...any) {
-	log.Debug().Msgf(format, v...)
-}
-
 func (o *updateCliOpts) Run(cmd *cobra.Command) error {
-	selfupdate.SetLogger(selfupdateLogger{})
+	ctx := cmd.Context()
 
 	prerelease := o.flagPrerelease || version.IsPrerelease() || version.IsDevBuild()
 	if prerelease {
@@ -58,49 +45,35 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 		log.Info().Msgf("Checking for the latest Metaplay CLI version...")
 	}
 
-	source, err := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{})
+	// Detect the latest version via the non-throttled github.com endpoints (see internal/version/detect.go).
+	latest, err := version.DetectLatest(ctx, prerelease)
 	if err != nil {
-		return fmt.Errorf("failed to initialize the Metaplay CLI updater source: %w", err)
+		return clierrors.Wrap(err, "Failed to detect the latest Metaplay CLI version").
+			WithSuggestion("Check your network connection, or download a release manually from https://github.com/metaplay/cli/releases")
 	}
 
-	var updateSource selfupdate.Source = source
-	if prerelease {
-		updateSource = &version.PrereleaseOnlySource{Inner: updateSource}
-	}
-
-	updater, err := selfupdate.NewUpdater(selfupdate.Config{
-		Source:     updateSource,
-		Prerelease: prerelease,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to initialize the Metaplay CLI updater: %w", err)
-	}
-
-	latest, found, err := updater.DetectLatest(context.Background(), selfupdate.ParseSlug("metaplay/cli"))
-	if err != nil {
-		return fmt.Errorf("failed to detect the latest Metaplay CLI version: %w", err)
-	}
-	if !found {
+	if !version.IsNewer(latest, version.AppVersion) {
 		log.Info().Msgf("Already on the latest Metaplay CLI version (%s)", version.AppVersion)
 		return nil
 	}
 
-	log.Info().Msgf("Downloading Metaplay CLI version %s...", styles.RenderTechnical(latest.Version()))
+	log.Info().Msgf("Downloading Metaplay CLI version %s...", styles.RenderTechnical(latest))
 
 	// Calling vendored implementation of `GetExecutablePath()` due to a bug in `selfupdate.GetExecutablePath()`
 	// that uses `filepath.EvalSymlinks()` known to be broken on Windows.
 	// A PR has been made for the `go-selfupdate` library: https://github.com/creativeprojects/go-selfupdate/pull/46
 	exe, err := pathutil.GetExecutablePath()
 	if err != nil {
-		return fmt.Errorf("could not determine the Metaplay CLI executable path: %w", err)
+		return clierrors.Wrap(err, "Could not determine the Metaplay CLI executable path")
 	}
 
-	if err := updater.UpdateTo(context.Background(), latest, exe); err != nil {
-		return fmt.Errorf("failed to update the Metaplay CLI binary: %w", err)
+	if err := version.DownloadAndApply(ctx, latest, exe); err != nil {
+		return clierrors.Wrap(err, "Failed to update the Metaplay CLI binary").
+			WithSuggestion("Check your network connection, or download a release manually from https://github.com/metaplay/cli/releases")
 	}
 
 	log.Info().Msg("")
-	log.Info().Msgf(styles.RenderSuccess("✅ Successfully updated to version %s!"), latest.Version())
+	log.Info().Msgf(styles.RenderSuccess("✅ Successfully updated to version %s!"), latest)
 
 	return nil
 }

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -13,6 +13,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// manualDownloadSuggestion is shown when an update fails for a reason the user can work
+// around by fetching a release themselves.
+const manualDownloadSuggestion = "Check your network connection, or download a release manually from https://github.com/metaplay/cli/releases"
+
 type updateCliOpts struct {
 	flagPrerelease bool
 }
@@ -49,10 +53,12 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 	latest, err := version.DetectLatest(ctx, prerelease)
 	if err != nil {
 		return clierrors.Wrap(err, "Failed to detect the latest Metaplay CLI version").
-			WithSuggestion("Check your network connection, or download a release manually from https://github.com/metaplay/cli/releases")
+			WithSuggestion(manualDownloadSuggestion)
 	}
 
-	if !version.IsNewer(latest, version.AppVersion) {
+	// A local "dev" build has no parseable version, so IsNewer can't compare it; always
+	// proceed in that case so `update cli` can move a locally built binary onto a release.
+	if !version.IsDevBuild() && !version.IsNewer(latest, version.AppVersion) {
 		log.Info().Msgf("Already on the latest Metaplay CLI version (%s)", version.AppVersion)
 		return nil
 	}
@@ -69,7 +75,7 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 
 	if err := version.DownloadAndApply(ctx, latest, exe); err != nil {
 		return clierrors.Wrap(err, "Failed to update the Metaplay CLI binary").
-			WithSuggestion("Check your network connection, or download a release manually from https://github.com/metaplay/cli/releases")
+			WithSuggestion(manualDownloadSuggestion)
 	}
 
 	log.Info().Msg("")

--- a/internal/version/detect.go
+++ b/internal/version/detect.go
@@ -86,11 +86,15 @@ func detectLatestGA(ctx context.Context) (string, error) {
 }
 
 // parseTagFromLocation extracts the version from a /releases/latest redirect target, which
-// looks like https://github.com/metaplay/cli/releases/tag/1.11.0.
+// looks like https://github.com/metaplay/cli/releases/tag/1.11.0. If no GA release exists,
+// GitHub instead redirects to .../releases (no /tag/ segment); we reject that explicitly so
+// it surfaces as a clear error rather than a bogus "releases" version.
 func parseTagFromLocation(location string) (string, error) {
+	if !strings.Contains(location, "/releases/tag/") {
+		return "", fmt.Errorf("redirect URL %q does not point to a release tag (no release published?)", location)
+	}
 	tag := strings.TrimPrefix(path.Base(location), "v")
-	switch tag {
-	case "", ".", "/", "latest":
+	if tag == "" {
 		return "", fmt.Errorf("could not parse a version from redirect URL %q", location)
 	}
 	return tag, nil
@@ -109,6 +113,10 @@ type atomFeed struct {
 // detectLatestDev resolves the latest dev/prerelease version from the releases Atom feed.
 // The feed lists releases (including prereleases) newest-first; we pick the highest dev
 // version by semver rather than relying on ordering.
+//
+// GitHub caps the feed at the 10 most recent releases. Dev releases are published on every
+// push (and old ones pruned), so the feed is normally dev-dominated; if it ever contains
+// only GA releases we return a clear "no dev release found" error rather than a wrong result.
 func detectLatestDev(ctx context.Context) (string, error) {
 	client := &http.Client{Timeout: httpTimeout}
 

--- a/internal/version/detect.go
+++ b/internal/version/detect.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-version"
+)
+
+const (
+	// repoSlug is the owner/repo of the CLI on GitHub.
+	repoSlug = "metaplay/cli"
+
+	// latestReleaseURL is the non-rate-limited web redirect to the latest GA release.
+	// Issuing a request returns a 302 to https://github.com/<repo>/releases/tag/<version>,
+	// from which we parse the version. This avoids api.github.com, which is throttled to
+	// 60 requests/hour/IP for unauthenticated requests.
+	latestReleaseURL = "https://github.com/" + repoSlug + "/releases/latest"
+
+	// releasesAtomURL is the non-rate-limited Atom feed of releases (including prereleases),
+	// served from github.com (not api.github.com). Used to detect the latest dev/prerelease
+	// version, which the GA redirect above intentionally skips.
+	releasesAtomURL = "https://github.com/" + repoSlug + "/releases.atom"
+
+	// downloadBaseURL is the CDN base for release assets. Downloads from here are not
+	// subject to the api.github.com rate limit.
+	downloadBaseURL = "https://github.com/" + repoSlug + "/releases/download"
+
+	// httpTimeout bounds every version-detection/download request so that the per-command
+	// background check can never hang a command for long when the network is slow or offline.
+	httpTimeout = 5 * time.Second
+)
+
+// DetectLatest returns the latest available version. When prerelease is true it returns the
+// latest dev/prerelease version (from the Atom feed); otherwise it returns the latest GA
+// release (from the /releases/latest redirect). Neither path touches the throttled
+// api.github.com endpoint.
+func DetectLatest(ctx context.Context, prerelease bool) (string, error) {
+	if prerelease {
+		return detectLatestDev(ctx)
+	}
+	return detectLatestGA(ctx)
+}
+
+// detectLatestGA resolves the latest GA version via the github.com /releases/latest redirect.
+func detectLatestGA(ctx context.Context) (string, error) {
+	// Disable redirect following so we can read the Location header of the 302 ourselves.
+	client := &http.Client{
+		Timeout: httpTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, latestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to query %s: %w", latestReleaseURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
+		return "", fmt.Errorf("unexpected status %d from %s (expected a redirect to the latest release)", resp.StatusCode, latestReleaseURL)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("no Location header in redirect from %s", latestReleaseURL)
+	}
+	return parseTagFromLocation(location)
+}
+
+// parseTagFromLocation extracts the version from a /releases/latest redirect target, which
+// looks like https://github.com/metaplay/cli/releases/tag/1.11.0.
+func parseTagFromLocation(location string) (string, error) {
+	tag := strings.TrimPrefix(path.Base(location), "v")
+	switch tag {
+	case "", ".", "/", "latest":
+		return "", fmt.Errorf("could not parse a version from redirect URL %q", location)
+	}
+	return tag, nil
+}
+
+// atomFeed is the minimal subset of the GitHub releases Atom feed that we parse.
+type atomFeed struct {
+	Entries []struct {
+		Title string `xml:"title"`
+		Link  struct {
+			Href string `xml:"href,attr"`
+		} `xml:"link"`
+	} `xml:"entry"`
+}
+
+// detectLatestDev resolves the latest dev/prerelease version from the releases Atom feed.
+// The feed lists releases (including prereleases) newest-first; we pick the highest dev
+// version by semver rather than relying on ordering.
+func detectLatestDev(ctx context.Context) (string, error) {
+	client := &http.Client{Timeout: httpTimeout}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesAtomURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to query %s: %w", releasesAtomURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, releasesAtomURL)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // feed is small; cap at 1 MiB
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", releasesAtomURL, err)
+	}
+	return parseLatestDevFromAtom(body)
+}
+
+// parseLatestDevFromAtom returns the highest dev/prerelease version found in a GitHub
+// releases Atom feed. The feed lists releases newest-first, but we pick by semver rather
+// than relying on ordering.
+func parseLatestDevFromAtom(body []byte) (string, error) {
+	var feed atomFeed
+	if err := xml.Unmarshal(body, &feed); err != nil {
+		return "", fmt.Errorf("failed to parse the releases Atom feed: %w", err)
+	}
+
+	var best *version.Version
+	var bestTag string
+	for _, entry := range feed.Entries {
+		// Prefer the tag from the link href; fall back to the title.
+		tag := strings.TrimPrefix(path.Base(entry.Link.Href), "v")
+		if tag == "" {
+			tag = strings.TrimPrefix(entry.Title, "v")
+		}
+		if !strings.Contains(tag, "-dev.") {
+			continue
+		}
+		v, err := version.NewVersion(tag)
+		if err != nil {
+			continue
+		}
+		if best == nil || v.GreaterThan(best) {
+			best = v
+			bestTag = tag
+		}
+	}
+
+	if bestTag == "" {
+		return "", fmt.Errorf("no dev release found in the releases Atom feed")
+	}
+	return bestTag, nil
+}
+
+// IsNewer reports whether candidate is a strictly newer version than current.
+// Both are plain version strings (no leading 'v'). On parse failure it returns false,
+// so a malformed version is never treated as an available update.
+func IsNewer(candidate, current string) bool {
+	c, err := version.NewVersion(candidate)
+	if err != nil {
+		return false
+	}
+	cur, err := version.NewVersion(current)
+	if err != nil {
+		return false
+	}
+	return c.GreaterThan(cur)
+}
+
+// assetURL builds the CDN download URL for the release archive of the given version,
+// matching the goreleaser archive name templates in .goreleaser.yaml / .goreleaser-dev.yaml.
+// Keep this in sync with those templates and with install.sh / install.ps1.
+func assetURL(tag string) string {
+	osTitle := map[string]string{
+		"linux":   "Linux",
+		"windows": "Windows",
+		"darwin":  "Darwin",
+	}[runtime.GOOS]
+
+	arch := map[string]string{
+		"amd64": "x86_64",
+		"arm64": "arm64",
+	}[runtime.GOARCH]
+
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+
+	name := fmt.Sprintf("MetaplayCLI_%s_%s.%s", osTitle, arch, ext)
+	return fmt.Sprintf("%s/%s/%s", downloadBaseURL, tag, name)
+}

--- a/internal/version/detect_test.go
+++ b/internal/version/detect_test.go
@@ -47,6 +47,8 @@ func TestParseTagFromLocation(t *testing.T) {
 		{"https://github.com/metaplay/cli/releases/tag/1.11.1-dev.12", "1.11.1-dev.12", false},
 		// No actual release (redirect points back to /releases/latest).
 		{"https://github.com/metaplay/cli/releases/latest", "", true},
+		// No release published at all (GitHub redirects to .../releases, no /tag/ segment).
+		{"https://github.com/metaplay/cli/releases", "", true},
 		{"", "", true},
 	}
 	for _, tt := range tests {

--- a/internal/version/detect_test.go
+++ b/internal/version/detect_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		candidate string
+		current   string
+		want      bool
+	}{
+		{"1.1.0", "1.0.0", true},
+		{"1.0.0", "1.0.0", false},
+		{"1.0.0", "1.1.0", false},
+		// Prerelease ordering.
+		{"1.11.1-dev.12", "1.11.1-dev.5", true},
+		{"1.11.1-dev.5", "1.11.1-dev.12", false},
+		// A GA release is newer than any prerelease of the same base version.
+		{"1.11.1", "1.11.1-dev.12", true},
+		{"1.11.1-dev.12", "1.11.1", false},
+		// Malformed versions are never treated as an update.
+		{"not-a-version", "1.0.0", false},
+		{"1.0.0", "not-a-version", false},
+	}
+	for _, tt := range tests {
+		if got := IsNewer(tt.candidate, tt.current); got != tt.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", tt.candidate, tt.current, got, tt.want)
+		}
+	}
+}
+
+func TestParseTagFromLocation(t *testing.T) {
+	tests := []struct {
+		location string
+		want     string
+		wantErr  bool
+	}{
+		{"https://github.com/metaplay/cli/releases/tag/1.11.0", "1.11.0", false},
+		{"https://github.com/metaplay/cli/releases/tag/v1.11.0", "1.11.0", false},
+		{"https://github.com/metaplay/cli/releases/tag/1.11.1-dev.12", "1.11.1-dev.12", false},
+		// No actual release (redirect points back to /releases/latest).
+		{"https://github.com/metaplay/cli/releases/latest", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		got, err := parseTagFromLocation(tt.location)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseTagFromLocation(%q) error = %v, wantErr %v", tt.location, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseTagFromLocation(%q) = %q, want %q", tt.location, got, tt.want)
+		}
+	}
+}
+
+func TestParseLatestDevFromAtom(t *testing.T) {
+	// Entries are intentionally NOT in version order to verify we pick by semver, not position.
+	feed := `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>1.11.1-dev.9</title>
+    <link rel="alternate" type="text/html" href="https://github.com/metaplay/cli/releases/tag/1.11.1-dev.9"/>
+  </entry>
+  <entry>
+    <title>1.11.1-dev.12</title>
+    <link rel="alternate" type="text/html" href="https://github.com/metaplay/cli/releases/tag/1.11.1-dev.12"/>
+  </entry>
+  <entry>
+    <title>1.11.1-dev.10</title>
+    <link rel="alternate" type="text/html" href="https://github.com/metaplay/cli/releases/tag/1.11.1-dev.10"/>
+  </entry>
+</feed>`
+
+	got, err := parseLatestDevFromAtom([]byte(feed))
+	if err != nil {
+		t.Fatalf("parseLatestDevFromAtom() unexpected error: %v", err)
+	}
+	if got != "1.11.1-dev.12" {
+		t.Errorf("parseLatestDevFromAtom() = %q, want %q", got, "1.11.1-dev.12")
+	}
+}
+
+func TestParseLatestDevFromAtom_NoDevReleases(t *testing.T) {
+	// A feed containing only GA releases should yield no dev version.
+	feed := `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>1.11.0</title>
+    <link rel="alternate" type="text/html" href="https://github.com/metaplay/cli/releases/tag/1.11.0"/>
+  </entry>
+</feed>`
+
+	if _, err := parseLatestDevFromAtom([]byte(feed)); err == nil {
+		t.Error("parseLatestDevFromAtom() expected an error for a GA-only feed, got nil")
+	}
+}
+
+func TestAssetURL(t *testing.T) {
+	url := assetURL("1.11.0")
+
+	if !strings.HasPrefix(url, "https://github.com/metaplay/cli/releases/download/1.11.0/MetaplayCLI_") {
+		t.Errorf("assetURL() has unexpected prefix: %s", url)
+	}
+
+	// The archive extension must match what goreleaser produces for this platform.
+	wantExt := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		wantExt = ".zip"
+	}
+	if !strings.HasSuffix(url, wantExt) {
+		t.Errorf("assetURL() = %s, want suffix %s for GOOS=%s", url, wantExt, runtime.GOOS)
+	}
+
+	// Sanity-check the OS/arch tokens for the platforms goreleaser builds.
+	switch runtime.GOOS {
+	case "linux":
+		if !strings.Contains(url, "_Linux_") {
+			t.Errorf("assetURL() = %s, expected _Linux_ token", url)
+		}
+	case "windows":
+		if !strings.Contains(url, "_Windows_") {
+			t.Errorf("assetURL() = %s, expected _Windows_ token", url)
+		}
+	case "darwin":
+		if !strings.Contains(url, "_Darwin_") {
+			t.Errorf("assetURL() = %s, expected _Darwin_ token", url)
+		}
+	}
+}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -9,15 +9,10 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"time"
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/creativeprojects/go-selfupdate/update"
 )
-
-// downloadTimeout bounds the asset download. It's larger than httpTimeout because the
-// archive is several MB and pulled from the CDN.
-const downloadTimeout = 60 * time.Second
 
 // DownloadAndApply downloads the release archive for the given version from the GitHub
 // CDN (not the throttled api.github.com), extracts the 'metaplay' binary, and atomically
@@ -25,16 +20,19 @@ const downloadTimeout = 60 * time.Second
 //
 // It reuses go-selfupdate's standalone helpers for the archive handling and the safe,
 // cross-platform binary swap, so we don't have to reimplement either.
+//
+// The archive is tens of MB, so this deliberately does NOT impose a hard timeout (a slow
+// connection should not fail a legitimate update). Cancellation is governed by ctx, so the
+// caller can bound or interrupt it (e.g. Ctrl+C via the command context).
 func DownloadAndApply(ctx context.Context, tag, exePath string) error {
 	url := assetURL(tag)
 
-	client := &http.Client{Timeout: downloadTimeout}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to download %s: %w", url, err)
 	}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/creativeprojects/go-selfupdate"
+	"github.com/creativeprojects/go-selfupdate/update"
+)
+
+// downloadTimeout bounds the asset download. It's larger than httpTimeout because the
+// archive is several MB and pulled from the CDN.
+const downloadTimeout = 60 * time.Second
+
+// DownloadAndApply downloads the release archive for the given version from the GitHub
+// CDN (not the throttled api.github.com), extracts the 'metaplay' binary, and atomically
+// replaces the executable at exePath.
+//
+// It reuses go-selfupdate's standalone helpers for the archive handling and the safe,
+// cross-platform binary swap, so we don't have to reimplement either.
+func DownloadAndApply(ctx context.Context, tag, exePath string) error {
+	url := assetURL(tag)
+
+	client := &http.Client{Timeout: downloadTimeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: unexpected status %d", url, resp.StatusCode)
+	}
+
+	// Extract the 'metaplay' binary from the archive (format detected from the URL suffix).
+	binary, err := selfupdate.DecompressCommand(resp.Body, url, "metaplay", runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return fmt.Errorf("failed to extract the binary from %s: %w", url, err)
+	}
+
+	// Atomically replace the running executable (rename-with-rollback; Windows-safe).
+	if err := update.Apply(binary, update.Options{TargetPath: exePath}); err != nil {
+		return fmt.Errorf("failed to replace the executable: %w", err)
+	}
+	return nil
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/metaplay/cli/internal/envutil"
@@ -34,7 +35,7 @@ func IsPrerelease() bool {
 	return strings.Contains(AppVersion, "-dev.")
 }
 
-func CheckVersion(stderrLogger *zerolog.Logger) {
+func CheckVersion(ctx context.Context, stderrLogger *zerolog.Logger) {
 	if IsDevBuild() {
 		log.Debug().Msgf("Skipping version check for development build (version is '%s')", AppVersion)
 		return
@@ -46,7 +47,7 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 	// Errors are only logged, not fatal, so the command still runs if the check fails.
 	// The request is bounded by a short timeout so it can't hang the command.
 	usePrerelease := IsPrerelease()
-	latest, err := DetectLatest(context.Background(), usePrerelease)
+	latest, err := DetectLatest(ctx, usePrerelease)
 	if err != nil {
 		log.Debug().Msgf("Failed to detect the latest Metaplay CLI version: %v", err)
 		return
@@ -67,7 +68,12 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 			log.Debug().Msgf("Auto-update failed: could not determine executable path: %v", err)
 			return
 		}
-		if err := DownloadAndApply(context.Background(), latest, exe); err != nil {
+		// Bound the background download: it runs on every command for prerelease builds, so a
+		// stalled connection must not hang the command indefinitely. Ctrl+C still interrupts via
+		// the command context; the timeout is generous enough for a large archive on a slow link.
+		dlCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
+		if err := DownloadAndApply(dlCtx, latest, exe); err != nil {
 			log.Debug().Msgf("Auto-update failed: %v", err)
 			return
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,11 +7,9 @@ package version
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"unicode/utf8"
 
-	"github.com/creativeprojects/go-selfupdate"
 	"github.com/metaplay/cli/internal/envutil"
 	"github.com/metaplay/cli/internal/pathutil"
 	"github.com/metaplay/cli/pkg/styles"
@@ -36,31 +34,6 @@ func IsPrerelease() bool {
 	return strings.Contains(AppVersion, "-dev.")
 }
 
-// PrereleaseOnlySource wraps a Source and filters ListReleases to only return
-// prerelease releases. This ensures the updater stays on the prerelease channel
-// and won't "upgrade" to a GA release.
-type PrereleaseOnlySource struct {
-	Inner selfupdate.Source
-}
-
-func (s *PrereleaseOnlySource) ListReleases(ctx context.Context, repository selfupdate.Repository) ([]selfupdate.SourceRelease, error) {
-	releases, err := s.Inner.ListReleases(ctx, repository)
-	if err != nil {
-		return nil, err
-	}
-	filtered := make([]selfupdate.SourceRelease, 0, len(releases))
-	for _, r := range releases {
-		if r.GetPrerelease() {
-			filtered = append(filtered, r)
-		}
-	}
-	return filtered, nil
-}
-
-func (s *PrereleaseOnlySource) DownloadReleaseAsset(ctx context.Context, rel *selfupdate.Release, assetID int64) (io.ReadCloser, error) {
-	return s.Inner.DownloadReleaseAsset(ctx, rel, assetID)
-}
-
 func CheckVersion(stderrLogger *zerolog.Logger) {
 	if IsDevBuild() {
 		log.Debug().Msgf("Skipping version check for development build (version is '%s')", AppVersion)
@@ -69,42 +42,17 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 
 	log.Debug().Msgf("Checking for new CLI version (current: v%s)", AppVersion)
 
-	// Check for new releases using go-selfupdate.
-	// Errors are only logged, not fatal, in order to allow the command to run even if the version check fails.
-	ghSource, err := selfupdate.NewGitHubSource(selfupdate.GitHubConfig{
-		APIToken: "", // Public repo doesn't need auth
-	})
-	if err != nil {
-		log.Debug().Msg("Error: Failed to initialize the Metaplay CLI self-updater source")
-		return
-	}
-
-	var source selfupdate.Source = ghSource
+	// Detect the latest version via the non-throttled github.com endpoints (see detect.go).
+	// Errors are only logged, not fatal, so the command still runs if the check fails.
+	// The request is bounded by a short timeout so it can't hang the command.
 	usePrerelease := IsPrerelease()
-	if usePrerelease {
-		source = &PrereleaseOnlySource{Inner: source}
-	}
-
-	updater, err := selfupdate.NewUpdater(selfupdate.Config{
-		Source:     source,
-		Prerelease: usePrerelease,
-	})
+	latest, err := DetectLatest(context.Background(), usePrerelease)
 	if err != nil {
-		log.Debug().Msg("Error: Failed to initialize the Metaplay CLI self-updater")
+		log.Debug().Msgf("Failed to detect the latest Metaplay CLI version: %v", err)
 		return
 	}
 
-	latest, found, err := updater.DetectLatest(context.Background(), selfupdate.ParseSlug("metaplay/cli"))
-	if err != nil {
-		log.Debug().Msg("Error: Failed to detect the latest Metaplay CLI version")
-		return
-	}
-
-	if !found {
-		return
-	}
-
-	if !latest.GreaterThan(AppVersion) {
+	if !IsNewer(latest, AppVersion) {
 		return
 	}
 
@@ -112,23 +60,23 @@ func CheckVersion(stderrLogger *zerolog.Logger) {
 	if usePrerelease && !envutil.IsCI() {
 		stderrLogger.Info().Msgf("Auto-updating CLI from %s to %s...",
 			styles.RenderError(AppVersion),
-			styles.RenderSuccess(latest.Version()),
+			styles.RenderSuccess(latest),
 		)
 		exe, err := pathutil.GetExecutablePath()
 		if err != nil {
 			log.Debug().Msgf("Auto-update failed: could not determine executable path: %v", err)
 			return
 		}
-		if err := updater.UpdateTo(context.Background(), latest, exe); err != nil {
+		if err := DownloadAndApply(context.Background(), latest, exe); err != nil {
 			log.Debug().Msgf("Auto-update failed: %v", err)
 			return
 		}
-		stderrLogger.Info().Msgf(styles.RenderSuccess("Updated CLI to %s.") + " Note: this command is still running with the previous version.", latest.Version())
+		stderrLogger.Info().Msgf(styles.RenderSuccess("Updated CLI to %s.")+" Note: this command is still running with the previous version.", latest)
 		return
 	}
 
 	// GA builds: show update banner.
-	for _, line := range renderUpdateBanner(AppVersion, latest.Version()) {
+	for _, line := range renderUpdateBanner(AppVersion, latest) {
 		stderrLogger.Info().Msg(line)
 	}
 }


### PR DESCRIPTION
## Problem

`metaplay update cli` (and the per-command update banner) failed with:

```
Error: failed to detect the latest Metaplay CLI version: GET https://api.github.com/repos/metaplay/cli/releases: 403 API rate limit exceeded
```

Both paths used `go-selfupdate`'s `DetectLatest`, which calls `api.github.com/repos/metaplay/cli/releases`. That endpoint is rate-limited to **60 requests/hour/IP** for unauthenticated requests, so multiple users behind a shared office NAT exhaust it. The banner check made it worse: it ran the same API call on essentially every command.

The installer scripts (`install.sh`/`install.ps1`) already sidestep this by resolving versions from the non-throttled `github.com` redirect — the Go code was the one place still on the API.

## Fix

Detect versions via the same non-throttled `github.com` endpoints:

- **GA builds** → the `/releases/latest` 302 redirect, parsing the version from the `Location` header.
- **dev/prerelease builds** → the `releases.atom` feed, picking the highest `-dev.` version by semver.

Downloads come from the `releases/download` CDN (also non-throttled). `go-selfupdate` is kept **only** for its standalone `DecompressCommand` and `update.Apply` helpers, so archive handling and the atomic, cross-platform binary swap are unchanged. No new dependency.

## Behavior

- **Prerelease builds (`x.y.z-dev.N`)** still run the full version check on every command and auto-update to a newer prerelease when available (except in CI). This is intentional and preserved.
- **GA builds** show the update banner.
- **Local `dev` builds** skip the background banner; `metaplay update cli` from a local build still installs the latest (release/prerelease).
- **No caching** — detection runs each time so new releases propagate immediately.

## Timeouts / cancellation

- Detection calls (small redirect / Atom responses) get a short 5s timeout; previously there was none.
- The download is not capped by a hard total-time timeout (the archive is ~26 MB; a slow link shouldn't fail a legitimate update). The command context governs cancellation (Ctrl+C). The per-command prerelease auto-update additionally bounds the download to 10 minutes so a stalled connection can't hang commands.

## Notes

- Removes the `PrereleaseOnlySource`/`Updater`/`SetLogger` plumbing that hit the API.
- `assetURL` mirrors the goreleaser archive-name template (same coupling the install scripts already carry); a comment cross-references them.

## Review

Reviewed at high effort with independent finder passes (correctness, removed-behavior/cross-file, cleanup/conventions). Addressed:

- **`update cli` no-op on local `dev` builds** — `IsNewer` can't parse `"dev"`, which would make the explicit command silently do nothing; now skipped for dev builds so they can move onto a release.
- **Stalled-download hang** — the per-command prerelease auto-update used `context.Background()` with no timeout; now uses the command context bounded to 10 minutes (Ctrl+C interrupts).
- **Bogus version on a repo with no release** — `parseTagFromLocation` now requires a `/releases/tag/` redirect and errors clearly otherwise.
- Documented the `releases.atom` 10-entry cap; deduplicated the manual-download suggestion string.

Verified non-issues: prerelease builds never jump to GA (atom path filters to `-dev.`); hashicorp/go-version ordering matches the old Masterminds ordering (and no longer panics on unparseable input); `matchExecutableName` handles the Windows `.exe`; no other callers of the removed `PrereleaseOnlySource`.

## Testing

- Unit tests for version ordering, redirect parsing (incl. the no-release case), Atom parsing (semver pick, not feed order), and the asset-URL platform matrix.
- `make` (golangci-lint clean), `go vet`, `go mod tidy` (no changes).
- Live detection against the real repo: GA → `1.11.0`, dev → `1.11.1-dev.12`.

**End-to-end through the real `metaplay update cli` command** — built with a faked old version via ldflags, then self-replacing against real releases:

| Platform | Scenario | Result |
|---|---|---|
| Windows (host) | GA `1.0.0`: banner → `update cli` → `version` | banner `1.0.0 → 1.11.0`; self-replaced; reports `1.11.0` |
| Windows (host) | GA at latest (`1.11.0`) | `Already on the latest` — no download |
| Linux (docker `golang:1.26`) | GA `1.0.0` → `update cli` | self-replaced; reports `1.11.0` |
| Linux (docker `golang:1.26`) | prerelease `1.0.0-dev.1` → `update cli` | prerelease channel; self-replaced; reports `1.11.1-dev.12` |

This covers the full chain on both OSes: detection (GA redirect + dev Atom feed), CDN download, decompress (`.zip` / `.tar.gz`, incl. `metaplay.exe` matching), atomic self-replacement, and the banner / already-latest / channel-selection branches.