### PR TITLE
Retain id_token and refresh_token across token refreshes

### DIFF
--- a/pkg/auth/refresh.go
+++ b/pkg/auth/refresh.go
@@ -133,5 +133,19 @@ func refreshTokenSet(tokenSet *TokenSet, authProvider *AuthProviderConfig) (*Tok
 		return nil, clierrors.Wrap(err, "Failed to parse authentication tokens")
 	}
 
-	return &tokens, nil
+	return mergeRefreshedTokenSet(tokenSet, &tokens), nil
+}
+
+// mergeRefreshedTokenSet treats the refresh response as a delta: access_token comes from it,
+// while id_token and refresh_token are carried forward when omitted (Ory drops id_token on
+// refresh; refresh_token may be absent when rotation is disabled).
+func mergeRefreshedTokenSet(previous, refreshed *TokenSet) *TokenSet {
+	merged := *refreshed
+	if merged.IDToken == "" {
+		merged.IDToken = previous.IDToken
+	}
+	if merged.RefreshToken == "" {
+		merged.RefreshToken = previous.RefreshToken
+	}
+	return &merged
 }

--- a/pkg/auth/refresh_test.go
+++ b/pkg/auth/refresh_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package auth
+
+import "testing"
+
+func TestMergeRefreshedTokenSet(t *testing.T) {
+	previous := &TokenSet{
+		IDToken:      "old-id-token",
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+	}
+
+	tests := []struct {
+		name             string
+		refreshed        *TokenSet
+		wantIDToken      string
+		wantAccessToken  string
+		wantRefreshToken string
+	}{
+		{
+			name:             "server returns all fields",
+			refreshed:        &TokenSet{IDToken: "new-id-token", AccessToken: "new-access-token", RefreshToken: "new-refresh-token"},
+			wantIDToken:      "new-id-token",
+			wantAccessToken:  "new-access-token",
+			wantRefreshToken: "new-refresh-token",
+		},
+		{
+			name:             "server omits id_token (Ory behavior)",
+			refreshed:        &TokenSet{IDToken: "", AccessToken: "new-access-token", RefreshToken: "new-refresh-token"},
+			wantIDToken:      "old-id-token",
+			wantAccessToken:  "new-access-token",
+			wantRefreshToken: "new-refresh-token",
+		},
+		{
+			name:             "server omits refresh_token (rotation disabled)",
+			refreshed:        &TokenSet{IDToken: "new-id-token", AccessToken: "new-access-token", RefreshToken: ""},
+			wantIDToken:      "new-id-token",
+			wantAccessToken:  "new-access-token",
+			wantRefreshToken: "old-refresh-token",
+		},
+		{
+			name:             "server returns only a new access_token",
+			refreshed:        &TokenSet{IDToken: "", AccessToken: "new-access-token", RefreshToken: ""},
+			wantIDToken:      "old-id-token",
+			wantAccessToken:  "new-access-token",
+			wantRefreshToken: "old-refresh-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeRefreshedTokenSet(previous, tc.refreshed)
+			if got.IDToken != tc.wantIDToken {
+				t.Errorf("IDToken = %q, want %q", got.IDToken, tc.wantIDToken)
+			}
+			if got.AccessToken != tc.wantAccessToken {
+				t.Errorf("AccessToken = %q, want %q", got.AccessToken, tc.wantAccessToken)
+			}
+			if got.RefreshToken != tc.wantRefreshToken {
+				t.Errorf("RefreshToken = %q, want %q", got.RefreshToken, tc.wantRefreshToken)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`refreshTokenSet` saved the `refresh_token` grant response verbatim as the new session token set. But an OAuth2/OIDC refresh response is a *delta*, not a full replacement:

- Ory/Hydra does **not** return a new `id_token` on a refresh, so the stored `id_token` was wiped on the first refresh.
- A server with refresh-token rotation disabled may omit `refresh_token` from the response, which would drop it and silently sign the user out.

Losing the `id_token` is the more visible symptom: the CLI can no longer read the user's identity claims (`sub`/`email`/`name`) locally and is forced onto a UserInfo endpoint for every `auth whoami` / `get kubeconfig` call.

## Fix

Add `mergeRefreshedTokenSet`, which treats the refresh response as a delta over the previous token set: `access_token` always comes from the response, while `id_token` and `refresh_token` are carried forward from the previous set whenever the response omits them.

## Tests

First unit tests for `pkg/auth`:

- `TestMergeRefreshedTokenSet` — all-fields, omitted `id_token` (Ory behavior), omitted `refresh_token` (rotation disabled), and access-token-only responses.

## Notes

Independent correctness fix with no behavior change when the server returns all fields. A separate follow-up will use the now-retained `id_token` to resolve user info from claims and remove the dependency on the sunsetting portal `/api/external/userinfo` endpoint.