### PR TITLE
Resolve user info from token claims; drop /api/external/userinfo dependency

### DIFF
--- a/cmd/auth_whoami.go
+++ b/cmd/auth_whoami.go
@@ -103,11 +103,11 @@ func (o *authWhoamiOpts) Run(cmd *cobra.Command) error {
 		return nil
 	}
 
-	// Fetch user info from portal.
-	log.Debug().Msgf("Fetch user info...")
-	userInfo, err := auth.FetchUserInfo(authProvider, tokenSet)
+	// Resolve user info from the token claims.
+	log.Debug().Msgf("Resolve user info from token claims...")
+	userInfo, err := auth.ResolveUserInfo(tokenSet)
 	if err != nil {
-		log.Panic().Msgf("Failed to fetch user info: %v", err)
+		return err
 	}
 
 	// Output based on format

--- a/cmd/get_kubeconfig.go
+++ b/cmd/get_kubeconfig.go
@@ -92,16 +92,6 @@ func (o *getKubeConfigOpts) Run(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Resolve auth provider.
-	authProviderName := o.argAuthProvider
-	if authProviderName == "" {
-		authProviderName = "metaplay"
-	}
-	authProvider, err := getAuthProvider(project, authProviderName)
-	if err != nil {
-		return err
-	}
-
 	// Create environment helper.
 	targetEnv := envapi.NewTargetEnvironment(tokenSet, envConfig.StackDomain, envConfig.HumanID)
 
@@ -119,14 +109,17 @@ func (o *getKubeConfigOpts) Run(cmd *cobra.Command) error {
 	var kubeconfigPayload string
 	switch credentialsType {
 	case "dynamic":
-		// Fetch the userinfo for an email.
+		// Resolve an identity for the kubeconfig user label (cosmetic; auth uses the exec plugin).
 		var userinfo *auth.UserInfoResponse
-		userinfo, err = auth.FetchUserInfo(authProvider, tokenSet)
+		userinfo, err = auth.ResolveUserInfo(tokenSet)
 		if err != nil {
 			return err
 		}
-
-		kubeconfigPayload, err = targetEnv.GetKubeConfigWithExecCredential(userinfo.Email)
+		userID := userinfo.Email
+		if userID == "" {
+			userID = userinfo.Subject
+		}
+		kubeconfigPayload, err = targetEnv.GetKubeConfigWithExecCredential(userID)
 	case "static":
 		kubeconfigPayload, err = targetEnv.GetKubeConfigWithEmbeddedCredentials()
 	default:

--- a/pkg/auth/auth_provider.go
+++ b/pkg/auth/auth_provider.go
@@ -8,12 +8,13 @@ import "github.com/metaplay/cli/pkg/common"
 
 // OAuth2 client configuration.
 type AuthProviderConfig struct {
-	Name             string `yaml:"name"`             // Name of the provider (used as sessionID as well).
-	ClientID         string `yaml:"clientId"`         // OAuth2 client ID.
-	AuthEndpoint     string `yaml:"authEndpoint"`     // Eg, "https://auth.metaplay.dev/oauth2/auth".
-	TokenEndpoint    string `yaml:"tokenEndpoint"`    // Eg, "https://auth.metaplay.dev/oauth2/token".
-	RevokeEndpoint   string `yaml:"revokeEndpoint"`   // Eg, "https://auth.metaplay.dev/oauth2/revoke".
-	UserInfoEndpoint string `yaml:"userInfoEndpoint"` // Eg, "https://portal.metaplay.dev/api/external/userinfo"
+	Name           string `yaml:"name"`           // Name of the provider (used as sessionID as well).
+	ClientID       string `yaml:"clientId"`       // OAuth2 client ID.
+	AuthEndpoint   string `yaml:"authEndpoint"`   // Eg, "https://auth.metaplay.dev/oauth2/auth".
+	TokenEndpoint  string `yaml:"tokenEndpoint"`  // Eg, "https://auth.metaplay.dev/oauth2/token".
+	RevokeEndpoint string `yaml:"revokeEndpoint"` // Eg, "https://auth.metaplay.dev/oauth2/revoke".
+	// Unused: the CLI now resolves user info from token claims (auth.ResolveUserInfo). Kept for config compatibility.
+	UserInfoEndpoint string `yaml:"userInfoEndpoint"` // Eg, "https://portal.metaplay.dev/api/external/userinfo".
 	Scopes           string `yaml:"scopes"`           // Eg, "openid profile email offline_access"
 	Audience         string `yaml:"audience"`         // Eg, "managed-gameservers"
 }

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -16,8 +16,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	clierrors "github.com/metaplay/cli/internal/errors"
 	"github.com/metaplay/cli/pkg/httputil"
 	"github.com/metaplay/cli/pkg/styles"
@@ -217,35 +219,110 @@ func MachineLogin(authProvider *AuthProviderConfig, clientID, clientSecret strin
 		return fmt.Errorf("failed to save tokens: %w", err)
 	}
 
-	// Fetch the user info.
-	userinfo, err := FetchUserInfo(authProvider, &tokenSet)
-	if err != nil {
-		return err
-	}
-
-	log.Info().Msgf("You are now logged in with machine user %s %s (clientId=%s) and can execute other commands.", userinfo.GivenName, userinfo.FamilyName, userinfo.Subject)
+	log.Info().Msgf("You are now logged in as machine user (clientId=%s) and can execute other commands.", clientID)
 
 	return nil
 }
 
-func FetchUserInfo(authProvider *AuthProviderConfig, tokenSet *TokenSet) (*UserInfoResponse, error) {
-	log.Debug().Msgf("Fetch user info from %s", authProvider.UserInfoEndpoint)
+// Metaplay-namespaced claims emitted by the portal's Ory claims webhook (present on both tokens).
+const (
+	claimMetaplayEmail = "https://schemas.metaplay.io/email"
+	claimMetaplayRoles = "https://schemas.metaplay.io/roles"
+)
 
-	var userinfo UserInfoResponse
-	resp, err := httputil.NewRetryClient().R().
-		SetAuthToken(tokenSet.AccessToken). // Set Bearer token for Authorization
-		SetResult(&userinfo).               // Unmarshal response into the struct
-		Get(authProvider.UserInfoEndpoint)
+// ResolveUserInfo builds the user's profile from the token claims, without contacting any UserInfo
+// endpoint. The access token (always present) supplies the subject and, for Metaplay Auth, a
+// namespaced email; the ID token (human logins) adds the standard OIDC profile claims and overrides.
+// Machine logins have no ID token and resolve to the subject (plus namespaced email, if present).
+func ResolveUserInfo(tokenSet *TokenSet) (*UserInfoResponse, error) {
+	info := &UserInfoResponse{}
 
+	if claims, err := parseTokenClaims(tokenSet.AccessToken); err == nil {
+		applyClaims(info, claims)
+	} else {
+		log.Debug().Msgf("Failed to parse access token claims: %v", err)
+	}
+	if tokenSet.IDToken != "" {
+		if claims, err := parseTokenClaims(tokenSet.IDToken); err == nil {
+			applyClaims(info, claims)
+		} else {
+			log.Debug().Msgf("Failed to parse ID token claims: %v", err)
+		}
+	}
+
+	if info.Subject == "" {
+		return nil, clierrors.New("Could not resolve user identity from the stored tokens").
+			WithSuggestion("Run 'metaplay auth login' to re-authenticate")
+	}
+	if info.Name == "" {
+		info.Name = strings.TrimSpace(info.GivenName + " " + info.FamilyName)
+	}
+	return info, nil
+}
+
+// parseTokenClaims decodes a JWT's claims without verifying its signature. Safe here: the token was
+// issued to us by the token endpoint over TLS and stored locally, and we only read our own identity
+// from it (the same trust model used for the access token's 'exp' claim).
+func parseTokenClaims(rawToken string) (jwt.MapClaims, error) {
+	token, _, err := jwt.NewParser().ParseUnverified(rawToken, jwt.MapClaims{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch userinfo: %w", err)
+		return nil, err
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("unexpected claims type %T", token.Claims)
+	}
+	return claims, nil
+}
+
+// applyClaims copies recognized profile claims into info, overwriting only with non-empty values so
+// a later, richer token (ID token) fills gaps left by an earlier one (access token) without clobbering.
+func applyClaims(info *UserInfoResponse, claims jwt.MapClaims) {
+	setIfNonEmpty(&info.Subject, claimString(claims, "sub"))
+	setIfNonEmpty(&info.Picture, claimString(claims, "picture"))
+	setIfNonEmpty(&info.GivenName, claimString(claims, "given_name"))
+	setIfNonEmpty(&info.FamilyName, claimString(claims, "family_name"))
+	setIfNonEmpty(&info.Name, claimString(claims, "name"))
+
+	// Prefer the standard OIDC email (ID token); fall back to the namespaced one (access token).
+	if email := claimString(claims, "email"); email != "" {
+		info.Email = email
+	} else {
+		setIfNonEmpty(&info.Email, claimString(claims, claimMetaplayEmail))
 	}
 
-	if resp.IsError() {
-		return nil, fmt.Errorf("API error: %s", resp.Status())
+	if roles := claimStringSlice(claims, claimMetaplayRoles); len(roles) > 0 {
+		info.Roles = roles
 	}
+}
 
-	return &userinfo, nil
+func setIfNonEmpty(dst *string, value string) {
+	if value != "" {
+		*dst = value
+	}
+}
+
+// claimString returns the named claim as a string, or "" if absent or not a string.
+func claimString(claims jwt.MapClaims, key string) string {
+	if v, ok := claims[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// claimStringSlice returns the named claim as a []string, or nil if absent or not an array of strings.
+func claimStringSlice(claims jwt.MapClaims, key string) []string {
+	raw, ok := claims[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // Exchange the OAuth2 code for the token set.

--- a/pkg/auth/login_test.go
+++ b/pkg/auth/login_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// makeToken builds a signed JWT from the given claims. The signature is irrelevant (claims are read
+// without verification) but keeps the token well-formed.
+func makeToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-key"))
+	if err != nil {
+		t.Fatalf("failed to sign test token: %v", err)
+	}
+	return signed
+}
+
+func TestResolveUserInfo(t *testing.T) {
+	t.Run("human profile from ID token", func(t *testing.T) {
+		ts := &TokenSet{
+			AccessToken: makeToken(t, jwt.MapClaims{"sub": "user-uuid"}),
+			IDToken: makeToken(t, jwt.MapClaims{
+				"sub":                               "user-uuid",
+				"email":                             "petri.kero@metaplay.io",
+				"given_name":                        "Petri",
+				"family_name":                       "Kero",
+				"picture":                           "https://example.com/a.png",
+				"https://schemas.metaplay.io/roles": []any{"metaplay.idler.develop.game-admin"},
+			}),
+		}
+		info, err := ResolveUserInfo(ts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Subject != "user-uuid" {
+			t.Errorf("Subject = %q", info.Subject)
+		}
+		if info.Email != "petri.kero@metaplay.io" {
+			t.Errorf("Email = %q", info.Email)
+		}
+		if info.Name != "Petri Kero" {
+			t.Errorf("Name = %q", info.Name)
+		}
+		if info.Picture != "https://example.com/a.png" {
+			t.Errorf("Picture = %q", info.Picture)
+		}
+		if len(info.Roles) != 1 || info.Roles[0] != "metaplay.idler.develop.game-admin" {
+			t.Errorf("Roles = %v", info.Roles)
+		}
+	})
+
+	t.Run("machine: subject and namespaced email from access token", func(t *testing.T) {
+		ts := &TokenSet{
+			AccessToken: makeToken(t, jwt.MapClaims{
+				"sub":                               "machine-uuid",
+				"https://schemas.metaplay.io/email": "svc@metaplay.io",
+			}),
+		}
+		info, err := ResolveUserInfo(ts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Subject != "machine-uuid" {
+			t.Errorf("Subject = %q", info.Subject)
+		}
+		if info.Email != "svc@metaplay.io" {
+			t.Errorf("Email = %q (want namespaced fallback)", info.Email)
+		}
+		if info.Name != "" {
+			t.Errorf("Name = %q, want empty for a machine user", info.Name)
+		}
+	})
+
+	t.Run("ID token overrides access token email and adds name", func(t *testing.T) {
+		ts := &TokenSet{
+			AccessToken: makeToken(t, jwt.MapClaims{"sub": "u", "https://schemas.metaplay.io/email": "namespaced@x"}),
+			IDToken:     makeToken(t, jwt.MapClaims{"sub": "u", "email": "standard@x", "given_name": "Ada", "family_name": "Lovelace"}),
+		}
+		info, err := ResolveUserInfo(ts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Email != "standard@x" {
+			t.Errorf("Email = %q, want standard@x (standard email wins)", info.Email)
+		}
+		if info.Name != "Ada Lovelace" {
+			t.Errorf("Name = %q, want composed from given/family", info.Name)
+		}
+	})
+
+	t.Run("error when tokens carry no subject", func(t *testing.T) {
+		ts := &TokenSet{AccessToken: makeToken(t, jwt.MapClaims{"foo": "bar"})}
+		if _, err := ResolveUserInfo(ts); err == nil {
+			t.Error("expected an error when no subject is present")
+		}
+	})
+}


### PR DESCRIPTION
**Draft / proposal** — opening for discussion before polishing. See open questions at the bottom.

## Motivation

The portal is sunsetting `/api/external/userinfo`. An endpoint can only be deleted once its **last** caller is gone, so a partial migration buys nothing toward that goal. This removes **every** CLI invocation of it, sourcing the user profile from the token claims the CLI already holds.

## What it does

`auth.FetchUserInfo` (HTTP GET to `UserInfoEndpoint`) is replaced by `auth.ResolveUserInfo(tokenSet)`, which reads claims locally — no network call:

- **Access token** (always present): `sub`, plus the Metaplay-namespaced `https://schemas.metaplay.io/email`.
- **ID token** (human logins): standard OIDC `email`, `given_name`, `family_name`, `name` — overrides where present.
- Machine logins (no ID token) resolve to `sub` (+ namespaced email if present).

Callers updated:
- `get kubeconfig` (dynamic): label = resolved email, falling back to `sub`. The label is cosmetic — `target_environment.go:277` notes it's *"stored in the kubeconfig but not used otherwise"*; auth is the `metaplay get kubernetes-execcredential` exec plugin.
- `machine-login`: success line now shows `clientId` (already known) instead of a fetched name.
- `auth whoami`: resolves from claims.

`UserInfoEndpoint` config is **retained** (field, defaults, and `metaplay-project.yaml` validation) for config compatibility, marked `Unused` in code since the CLI no longer calls it.

## Why the tokens carry this (SDK refs)

- `AuthUi/src/routes/consent.ts:34-68` — sets `email`/`given_name`/`family_name`/`name` on the **id_token** for human logins (when `email`/`profile` scopes are granted; the CLI requests both).
- `DeveloperPortal/.../ory/enrichclaims.post.ts:401-411` — adds `https://schemas.metaplay.io/{email,roles}` to **both** tokens; the CLI client is not in the portal ignore-list.

## Impact

- **Functional: none.** kubectl auth is unchanged (exec plugin); the kubeconfig label is cosmetic.
- **Cosmetic losses:** `whoami` no longer shows `picture` (not in any token); machine `whoami`/`machine-login` show `clientId`/`sub` rather than a name. `whoami --format json` will have an empty `picture`.
- Humans keep name + email (from the id_token). Reliable name/email across refreshes depends on #160 (id_token retention), now merged.

## Verified live

`auth whoami -v` on a real session: resolves from claims with **no** network call (instant), `email` populated from the namespaced access-token claim even without an id_token, `sub` present. Unit coverage added in `login_test.go` (human id-token, machine access-token, id-token override, no-subject error).

## Open questions for review

1. `get kubeconfig`'s `AUTH_PROVIDER` arg is now unused (its only role was selecting the userinfo endpoint). Kept registered for compatibility — remove it, or keep as a no-op?
2. Dropping `picture` from `whoami` acceptable? (Alternative: keep a single `whoami`-only call to the non-deprecated `/api/v1/users/me`.)
3. The namespaced-email path relies on `enrichclaims`, which the portal itself plans to deprecate. Standard id-token `email` is the durable human source; machines would lose email if that webhook goes away. Acceptable, or do machines need a successor endpoint?
4. `UserInfoEndpoint` is retained but unused — keep it indefinitely for config compatibility (current choice), or plan removal later?