### PR TITLE
Fail 'update cli' fast when the binary cannot be replaced

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,3 +66,9 @@ jobs:
 
       - name: Run unit tests
         run: go test ./...
+
+      # Report the self-update tests individually. Several of them need an ACL the runner may not
+      # be able to express, in which case they skip — and a skip is invisible without -v, so this
+      # job would look like it covered them when it did not.
+      - name: Report self-update test results
+        run: go test ./internal/version/ ./internal/pathutil/ ./cmd/ -count=1 -v -run 'Replaceable|Leftover|ForDisplay|UpdateTempPaths|ReplaceFailure|NotWritableDetails'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,3 +45,24 @@ jobs:
 
       - name: Run unit tests
         run: go test ./...
+
+  # The self-update path is Windows-specific: the binary swap, the ACL probe in
+  # internal/version/update_windows.go and the path handling in internal/pathutil/windows.go are
+  # all guarded by //go:build windows, so the Linux job above never compiles them.
+  test-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          show-progress: false # suppress the noisy progress status output
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+
+      - name: Run unit tests
+        run: go test ./...

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -5,6 +5,10 @@
 package cmd
 
 import (
+	"errors"
+	"io/fs"
+	"runtime"
+
 	clierrors "github.com/metaplay/cli/internal/errors"
 	"github.com/metaplay/cli/internal/pathutil"
 	"github.com/metaplay/cli/internal/version"
@@ -16,6 +20,24 @@ import (
 // manualDownloadSuggestion is shown when an update fails for a reason the user can work
 // around by fetching a release themselves.
 const manualDownloadSuggestion = "Check your network connection, or download a release manually from https://github.com/metaplay/cli/releases"
+
+// notWritableSuggestion is shown when the CLI cannot replace its own binary. Package manager
+// installs live in directories that only root/Administrator may write to, so the update has
+// to go through the package manager to keep its bookkeeping in sync.
+const notWritableSuggestion = "If you installed the CLI with a package manager, update it with that instead; otherwise re-run from an elevated shell (Administrator or sudo)"
+
+// notWritableDetails lists the install location and the package manager update commands that
+// apply on this platform.
+func notWritableDetails(exe string) []string {
+	details := []string{"Installed at: " + pathutil.ForDisplay(exe)}
+	if runtime.GOOS == "windows" {
+		return append(details,
+			"Chocolatey install: choco upgrade metaplay",
+			"Scoop install: scoop update metaplay",
+		)
+	}
+	return append(details, "Homebrew install: brew upgrade metaplay")
+}
 
 type updateCliOpts struct {
 	flagPrerelease bool
@@ -63,8 +85,6 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 		return nil
 	}
 
-	log.Info().Msgf("Downloading Metaplay CLI version %s...", styles.RenderTechnical(latest))
-
 	// Calling vendored implementation of `GetExecutablePath()` due to a bug in `selfupdate.GetExecutablePath()`
 	// that uses `filepath.EvalSymlinks()` known to be broken on Windows.
 	// A PR has been made for the `go-selfupdate` library: https://github.com/creativeprojects/go-selfupdate/pull/46
@@ -73,9 +93,25 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 		return clierrors.Wrap(err, "Could not determine the Metaplay CLI executable path")
 	}
 
+	// Check that the binary can be replaced before downloading tens of MB that we could not apply.
+	if err := version.CheckWritable(exe); err != nil {
+		return clierrors.Wrap(err, "Cannot replace the Metaplay CLI binary").
+			WithSuggestion(notWritableSuggestion).
+			WithDetails(notWritableDetails(exe)...)
+	}
+
+	log.Info().Msgf("Downloading Metaplay CLI version %s...", styles.RenderTechnical(latest))
+
 	if err := version.DownloadAndApply(ctx, latest, exe); err != nil {
-		return clierrors.Wrap(err, "Failed to update the Metaplay CLI binary").
-			WithSuggestion(manualDownloadSuggestion)
+		cliErr := clierrors.Wrap(err, "Failed to update the Metaplay CLI binary")
+
+		// The swap can still hit a permission wall that the pre-flight check cannot see, in
+		// which case the network-oriented hint would be actively misleading.
+		if errors.Is(err, fs.ErrPermission) {
+			return cliErr.WithSuggestion(notWritableSuggestion).
+				WithDetails(notWritableDetails(exe)...)
+		}
+		return cliErr.WithSuggestion(manualDownloadSuggestion)
 	}
 
 	log.Info().Msg("")

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -26,20 +26,30 @@ const manualDownloadSuggestion = "Check your network connection, or download a r
 // to go through the package manager to keep its bookkeeping in sync.
 const notWritableSuggestion = "If you installed the CLI with a package manager, update it with that instead; otherwise re-run from an elevated shell (Administrator or sudo)"
 
-// fileInUseSuggestion is shown when the swap is blocked by something other than permissions,
-// which in practice means a leftover file that another metaplay process still has open.
-const fileInUseSuggestion = "Make sure no other metaplay process is running, then try again"
+// fileInUseSuggestion is shown when a leftover file from an earlier update is held by another
+// process. Elevation cannot help: on Windows that file is the mapped image of a still-running
+// metaplay, and a mapped image cannot be deleted at any privilege level.
+const fileInUseSuggestion = "Close any other running metaplay process, then try again"
+
+// manualInstallSuggestion is the catch-all for a local failure that is neither a permission
+// wall nor a busy file, such as the executable having vanished from under us.
+const manualInstallSuggestion = "Download a release manually from https://github.com/metaplay/cli/releases"
 
 // replaceFailureError wraps a failure to replace the CLI binary, picking the hint from the
-// cause: only a permission wall warrants pointing at package managers or elevation. Anything
-// else keeps fallbackSuggestion, so the hint never misdescribes the problem.
+// cause so it never misdescribes the problem. Order matters: a busy leftover surfaces as
+// ERROR_ACCESS_DENIED on Windows, so it must be recognised before the permission check or it
+// would draw a useless "run elevated" hint.
 func replaceFailureError(err error, message, exe, fallbackSuggestion string) *clierrors.CLIError {
 	cliErr := clierrors.Wrap(err, message)
-	if errors.Is(err, fs.ErrPermission) {
+	switch {
+	case errors.Is(err, version.ErrLeftoverInUse):
+		return cliErr.WithSuggestion(fileInUseSuggestion)
+	case errors.Is(err, fs.ErrPermission):
 		return cliErr.WithSuggestion(notWritableSuggestion).
 			WithDetails(notWritableDetails(exe)...)
+	default:
+		return cliErr.WithSuggestion(fallbackSuggestion)
 	}
-	return cliErr.WithSuggestion(fallbackSuggestion)
 }
 
 // notWritableDetails lists the install location and the package manager update commands that
@@ -111,7 +121,7 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 
 	// Check that the binary can be replaced before downloading tens of MB that we could not apply.
 	if err := version.EnsureReplaceable(exe); err != nil {
-		return replaceFailureError(err, "Cannot replace the Metaplay CLI binary", exe, fileInUseSuggestion)
+		return replaceFailureError(err, "Cannot replace the Metaplay CLI binary", exe, manualInstallSuggestion)
 	}
 
 	log.Info().Msgf("Downloading Metaplay CLI version %s...", styles.RenderTechnical(latest))

--- a/cmd/update_cli.go
+++ b/cmd/update_cli.go
@@ -26,6 +26,22 @@ const manualDownloadSuggestion = "Check your network connection, or download a r
 // to go through the package manager to keep its bookkeeping in sync.
 const notWritableSuggestion = "If you installed the CLI with a package manager, update it with that instead; otherwise re-run from an elevated shell (Administrator or sudo)"
 
+// fileInUseSuggestion is shown when the swap is blocked by something other than permissions,
+// which in practice means a leftover file that another metaplay process still has open.
+const fileInUseSuggestion = "Make sure no other metaplay process is running, then try again"
+
+// replaceFailureError wraps a failure to replace the CLI binary, picking the hint from the
+// cause: only a permission wall warrants pointing at package managers or elevation. Anything
+// else keeps fallbackSuggestion, so the hint never misdescribes the problem.
+func replaceFailureError(err error, message, exe, fallbackSuggestion string) *clierrors.CLIError {
+	cliErr := clierrors.Wrap(err, message)
+	if errors.Is(err, fs.ErrPermission) {
+		return cliErr.WithSuggestion(notWritableSuggestion).
+			WithDetails(notWritableDetails(exe)...)
+	}
+	return cliErr.WithSuggestion(fallbackSuggestion)
+}
+
 // notWritableDetails lists the install location and the package manager update commands that
 // apply on this platform.
 func notWritableDetails(exe string) []string {
@@ -94,24 +110,16 @@ func (o *updateCliOpts) Run(cmd *cobra.Command) error {
 	}
 
 	// Check that the binary can be replaced before downloading tens of MB that we could not apply.
-	if err := version.CheckWritable(exe); err != nil {
-		return clierrors.Wrap(err, "Cannot replace the Metaplay CLI binary").
-			WithSuggestion(notWritableSuggestion).
-			WithDetails(notWritableDetails(exe)...)
+	if err := version.EnsureReplaceable(exe); err != nil {
+		return replaceFailureError(err, "Cannot replace the Metaplay CLI binary", exe, fileInUseSuggestion)
 	}
 
 	log.Info().Msgf("Downloading Metaplay CLI version %s...", styles.RenderTechnical(latest))
 
+	// The swap can still hit a permission wall that the pre-flight check could not see, so the
+	// network hint only applies when the failure is not about permissions.
 	if err := version.DownloadAndApply(ctx, latest, exe); err != nil {
-		cliErr := clierrors.Wrap(err, "Failed to update the Metaplay CLI binary")
-
-		// The swap can still hit a permission wall that the pre-flight check cannot see, in
-		// which case the network-oriented hint would be actively misleading.
-		if errors.Is(err, fs.ErrPermission) {
-			return cliErr.WithSuggestion(notWritableSuggestion).
-				WithDetails(notWritableDetails(exe)...)
-		}
-		return cliErr.WithSuggestion(manualDownloadSuggestion)
+		return replaceFailureError(err, "Failed to update the Metaplay CLI binary", exe, manualDownloadSuggestion)
 	}
 
 	log.Info().Msg("")

--- a/cmd/update_cli_test.go
+++ b/cmd/update_cli_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"runtime"
+	"testing"
+
+	"github.com/metaplay/cli/internal/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceFailureErrorPicksHintFromCause(t *testing.T) {
+	const exe = "/opt/metaplay/metaplay"
+
+	tests := []struct {
+		name           string
+		err            error
+		wantSuggestion string
+		wantDetails    bool
+	}{
+		{
+			name:           "an unwritable install points at the package manager",
+			err:            fmt.Errorf("cannot replace %s: %w", exe, fs.ErrPermission),
+			wantSuggestion: notWritableSuggestion,
+			wantDetails:    true,
+		},
+		{
+			// The case that matters most: on Windows a busy leftover reports
+			// ERROR_ACCESS_DENIED, which satisfies errors.Is(fs.ErrPermission). It must still be
+			// recognised as a busy file, or the user is told to elevate for a mapped image that
+			// no privilege level can delete.
+			name:           "a busy leftover wins over its permission errno",
+			err:            fmt.Errorf("%w: %s: %w", version.ErrLeftoverInUse, exe, fs.ErrPermission),
+			wantSuggestion: fileInUseSuggestion,
+			wantDetails:    false,
+		},
+		{
+			name:           "a busy leftover without a permission errno",
+			err:            fmt.Errorf("%w: %s: sharing violation", version.ErrLeftoverInUse, exe),
+			wantSuggestion: fileInUseSuggestion,
+			wantDetails:    false,
+		},
+		{
+			name:           "a missing executable falls back rather than blaming permissions",
+			err:            fmt.Errorf("cannot replace %s: %w", exe, fs.ErrNotExist),
+			wantSuggestion: manualInstallSuggestion,
+			wantDetails:    false,
+		},
+		{
+			name:           "an unclassified failure falls back",
+			err:            errors.New("archive is corrupt"),
+			wantSuggestion: manualInstallSuggestion,
+			wantDetails:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cliErr := replaceFailureError(tt.err, "Cannot replace the Metaplay CLI binary", exe, manualInstallSuggestion)
+
+			assert.Equal(t, tt.wantSuggestion, cliErr.Suggestion)
+			assert.Equal(t, "Cannot replace the Metaplay CLI binary", cliErr.Message)
+			assert.ErrorIs(t, cliErr, tt.err, "the cause must stay in the chain")
+
+			if tt.wantDetails {
+				assert.NotEmpty(t, cliErr.Details, "a permission failure should list where to update from")
+			} else {
+				assert.Empty(t, cliErr.Details, "only a permission failure should list package managers")
+			}
+		})
+	}
+}
+
+func TestReplaceFailureErrorUsesCallerFallback(t *testing.T) {
+	// The download call site needs the network-flavoured hint, not the pre-flight's.
+	cliErr := replaceFailureError(errors.New("unexpected status 500"),
+		"Failed to update the Metaplay CLI binary", "/opt/metaplay/metaplay", manualDownloadSuggestion)
+
+	assert.Equal(t, manualDownloadSuggestion, cliErr.Suggestion)
+}
+
+func TestNotWritableDetailsNamesInstallPathAndPlatformManagers(t *testing.T) {
+	details := notWritableDetails("/opt/metaplay/metaplay")
+
+	assert.Contains(t, details[0], "/opt/metaplay/metaplay", "the install path must be shown")
+
+	joined := fmt.Sprint(details)
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, joined, "choco upgrade metaplay")
+		assert.Contains(t, joined, "scoop update metaplay")
+		assert.NotContains(t, joined, "brew")
+	} else {
+		assert.Contains(t, joined, "brew upgrade metaplay")
+		assert.NotContains(t, joined, "choco")
+	}
+}

--- a/internal/pathutil/unix.go
+++ b/internal/pathutil/unix.go
@@ -11,6 +11,11 @@ import (
 	"path/filepath"
 )
 
+// ForDisplay returns the path unchanged; only Windows needs prefix cleanup.
+func ForDisplay(path string) string {
+	return path
+}
+
 // GetExecutablePath returns the path of the executable file with all symlinks resolved.
 func GetExecutablePath() (string, error) {
 	exe, err := os.Executable()

--- a/internal/pathutil/unix_test.go
+++ b/internal/pathutil/unix_test.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForDisplayPassesPathsThrough(t *testing.T) {
+	// Unix paths have no prefix to clean up, including ones that merely look like a Windows
+	// device path.
+	for _, path := range []string{
+		"/usr/local/bin/metaplay",
+		"/opt/homebrew/Cellar/metaplay/1.12.0/bin/metaplay",
+		`\\?\weird-but-valid-unix-filename`,
+	} {
+		assert.Equal(t, path, ForDisplay(path))
+	}
+}

--- a/internal/pathutil/windows.go
+++ b/internal/pathutil/windows.go
@@ -9,10 +9,21 @@ package pathutil
 import (
 	"fmt"
 	"os"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
+
+// ForDisplay strips the \\?\ extended-length prefix that GetExecutablePath returns, so paths
+// read naturally in user-facing messages. Only use it for display: the prefix is what allows
+// file operations on paths longer than MAX_PATH.
+func ForDisplay(path string) string {
+	if rest, ok := strings.CutPrefix(path, `\\?\UNC\`); ok {
+		return `\\` + rest
+	}
+	return strings.TrimPrefix(path, `\\?\`)
+}
 
 // GetExecutablePath returns the path of the executable file with all symlinks resolved.
 func GetExecutablePath() (string, error) {

--- a/internal/pathutil/windows.go
+++ b/internal/pathutil/windows.go
@@ -18,11 +18,32 @@ import (
 // ForDisplay strips the \\?\ extended-length prefix that GetExecutablePath returns, so paths
 // read naturally in user-facing messages. Only use it for display: the prefix is what allows
 // file operations on paths longer than MAX_PATH.
+//
+// Only the two forms that round-trip to something a user can act on are stripped — a drive
+// path and a UNC path. Other device forms such as \\?\Volume{GUID}\ and \\?\GLOBALROOT\ are
+// left intact, since stripping those yields a string that looks like a relative path and is
+// not usable anywhere.
 func ForDisplay(path string) string {
-	if rest, ok := strings.CutPrefix(path, `\\?\UNC\`); ok {
-		return `\\` + rest
+	rest, ok := strings.CutPrefix(path, `\\?\`)
+	if !ok {
+		return path
 	}
-	return strings.TrimPrefix(path, `\\?\`)
+
+	// \\?\UNC\server\share -> \\server\share. The prefix casing is not guaranteed.
+	if len(rest) >= 4 && strings.EqualFold(rest[:4], `UNC\`) {
+		return `\\` + rest[4:]
+	}
+
+	// \\?\C:\... -> C:\...
+	if len(rest) >= 3 && isDriveLetter(rest[0]) && rest[1] == ':' && rest[2] == '\\' {
+		return rest
+	}
+
+	return path
+}
+
+func isDriveLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 // GetExecutablePath returns the path of the executable file with all symlinks resolved.

--- a/internal/pathutil/windows_test.go
+++ b/internal/pathutil/windows_test.go
@@ -38,6 +38,28 @@ func TestForDisplay(t *testing.T) {
 			path:     `\\server\share\metaplay.exe`,
 			expected: `\\server\share\metaplay.exe`,
 		},
+		{
+			name:     "handles lower-case UNC prefixes",
+			path:     `\\?\unc\server\share\metaplay.exe`,
+			expected: `\\server\share\metaplay.exe`,
+		},
+		{
+			// Stripping this would yield something that reads as a relative path and is not
+			// usable anywhere, so it must be left as-is.
+			name:     "leaves volume GUID paths intact",
+			path:     `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\metaplay.exe`,
+			expected: `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\metaplay.exe`,
+		},
+		{
+			name:     "leaves GLOBALROOT paths intact",
+			path:     `\\?\GLOBALROOT\Device\HarddiskVolume1\metaplay.exe`,
+			expected: `\\?\GLOBALROOT\Device\HarddiskVolume1\metaplay.exe`,
+		},
+		{
+			name:     "leaves a bare prefix alone",
+			path:     `\\?\`,
+			expected: `\\?\`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pathutil/windows_test.go
+++ b/internal/pathutil/windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "strips the extended-length prefix",
+			path:     `\\?\C:\ProgramData\chocolatey\lib\metaplay\tools\metaplay.exe`,
+			expected: `C:\ProgramData\chocolatey\lib\metaplay\tools\metaplay.exe`,
+		},
+		{
+			name:     "restores UNC paths to their familiar form",
+			path:     `\\?\UNC\server\share\tools\metaplay.exe`,
+			expected: `\\server\share\tools\metaplay.exe`,
+		},
+		{
+			name:     "leaves an unprefixed path alone",
+			path:     `C:\Users\dev\metaplay.exe`,
+			expected: `C:\Users\dev\metaplay.exe`,
+		},
+		{
+			name:     "leaves a plain UNC path alone",
+			path:     `\\server\share\metaplay.exe`,
+			expected: `\\server\share\metaplay.exe`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ForDisplay(tt.path))
+		})
+	}
+}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -20,9 +20,30 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// ErrLeftoverInUse reports that a temp file from an earlier update could not be removed even
+// though the install itself is replaceable, which means another process is holding it.
+//
+// This must not be conflated with a permission problem. On Windows the file that update.Apply
+// leaves behind after every successful swap is the mapped image of the process that performed
+// it, and removing a mapped image fails with ERROR_ACCESS_DENIED — indistinguishable by errno
+// from an unwritable install, but no amount of elevation can fix it.
+var ErrLeftoverInUse = errors.New("a file left over from an earlier update could not be removed")
+
 // updateTempSuffixes are the temp files that update.Apply creates next to the target
 // executable while swapping the binary.
 var updateTempSuffixes = []string{".new", ".old"}
+
+// updateTempPaths returns the temp file paths update.Apply works with for the given target.
+// These must match the library's own construction (Dir + Base + "."+name+suffix), or the
+// cleanup below silently misses them.
+func updateTempPaths(exePath string) []string {
+	dir, name := filepath.Split(exePath)
+	paths := make([]string, 0, len(updateTempSuffixes))
+	for _, suffix := range updateTempSuffixes {
+		paths = append(paths, filepath.Join(dir, "."+name+suffix))
+	}
+	return paths
+}
 
 // EnsureReplaceable clears anything blocking an in-place update of the executable at exePath
 // and verifies that the swap can actually happen, so an unwritable install (a
@@ -33,13 +54,13 @@ var updateTempSuffixes = []string{".new", ".old"}
 // the target. It deliberately never opens the target for writing — on Windows a running
 // executable is locked against writes but can still be renamed, which is how the swap works.
 //
-// Permission failures wrap fs.ErrPermission, so callers can tell them apart from a leftover
-// that some other process is holding open.
+// Checks run cheapest and least destructive first, which also decides how failures are
+// reported: an install that can never be updated says so, rather than blaming a leftover file
+// that is merely a symptom.
 func EnsureReplaceable(exePath string) error {
-	// Clear leftovers from an interrupted earlier update first: Apply opens .<name>.new with
-	// O_TRUNC and fails outright if that file exists but is not writable by the current user
-	// (eg, left behind by a run with elevated privileges).
-	if err := removeStaleUpdateFiles(exePath); err != nil {
+	// Probe that the existing executable may be renamed out of the way. Free and non-destructive,
+	// so it goes first: on an install that can never self-update we then create nothing at all.
+	if err := checkReplaceable(exePath); err != nil {
 		return err
 	}
 
@@ -47,32 +68,48 @@ func EnsureReplaceable(exePath string) error {
 	dir := filepath.Dir(exePath)
 	probe, err := os.CreateTemp(dir, ".metaplay-update-probe-*")
 	if err != nil {
-		return fmt.Errorf("cannot create files in %s: %w", pathutil.ForDisplay(dir), err)
+		return fmt.Errorf("cannot create files in %s: %w", pathutil.ForDisplay(dir), unwrapPathError(err))
 	}
 	_ = probe.Close()
-	_ = os.Remove(probe.Name())
+	if err := os.Remove(probe.Name()); err != nil {
+		// Not fatal — the checks that matter already passed — but it leaves a file behind, so
+		// make it diagnosable instead of silent.
+		log.Debug().Msgf("Failed to remove the probe file %s: %v", probe.Name(), err)
+	}
 
-	// Probe that the existing executable may be renamed out of the way.
-	return checkReplaceable(exePath)
+	// Only now clear leftovers from an interrupted earlier update: Apply opens .<name>.new with
+	// O_TRUNC and fails outright if it exists but is not writable, and on Windows renaming the
+	// target to .old fails when .old already exists.
+	return removeStaleUpdateFiles(exePath)
 }
 
-// removeStaleUpdateFiles deletes .<name>.new / .<name>.old files left next to exePath by an
-// interrupted earlier update. A leftover that cannot be removed is reported as an error,
-// because Apply would fail on it later anyway: it truncates .new, and on Windows renaming
-// the target to .old fails when .old already exists.
+// removeStaleUpdateFiles deletes the temp files left next to exePath by an interrupted earlier
+// update. Failures are reported as ErrLeftoverInUse rather than wrapping the underlying errno,
+// so a mapped-image leftover can never be mistaken for an unwritable install; see
+// ErrLeftoverInUse. Every suffix is attempted, so one blocked file does not hide another.
 func removeStaleUpdateFiles(exePath string) error {
-	dir, name := filepath.Split(exePath)
-	for _, suffix := range updateTempSuffixes {
-		path := filepath.Join(dir, "."+name+suffix)
+	var errs []error
+	for _, path := range updateTempPaths(exePath) {
 		err := os.Remove(path)
 		switch {
 		case err == nil:
 			log.Debug().Msgf("Removed %s left over from an earlier update", path)
 		case !errors.Is(err, fs.ErrNotExist):
-			return fmt.Errorf("failed to remove %s left over from an earlier update: %w", pathutil.ForDisplay(path), err)
+			errs = append(errs, fmt.Errorf("%w: %s: %v",
+				ErrLeftoverInUse, pathutil.ForDisplay(path), unwrapPathError(err)))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
+}
+
+// unwrapPathError reduces an *fs.PathError to its cause, so a message that already names the
+// path via ForDisplay does not also print the raw \\?\-prefixed one the PathError carries.
+func unwrapPathError(err error) error {
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return pathErr.Err
+	}
+	return err
 }
 
 // DownloadAndApply downloads the release archive for the given version from the GitHub

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -24,14 +24,18 @@ import (
 // executable while swapping the binary.
 var updateTempSuffixes = []string{".new", ".old"}
 
-// CheckWritable verifies that the executable at exePath can actually be replaced in place,
-// so that an unwritable install (a package-manager-managed or system-wide location) fails
-// fast instead of only after a download of tens of MB.
+// EnsureReplaceable clears anything blocking an in-place update of the executable at exePath
+// and verifies that the swap can actually happen, so an unwritable install (a
+// package-manager-managed or system-wide location) fails fast rather than after a download of
+// tens of MB. It removes files, so it is not a read-only check.
 //
 // It probes what update.Apply does: create a file in the install directory, then rename over
 // the target. It deliberately never opens the target for writing — on Windows a running
 // executable is locked against writes but can still be renamed, which is how the swap works.
-func CheckWritable(exePath string) error {
+//
+// Permission failures wrap fs.ErrPermission, so callers can tell them apart from a leftover
+// that some other process is holding open.
+func EnsureReplaceable(exePath string) error {
 	// Clear leftovers from an interrupted earlier update first: Apply opens .<name>.new with
 	// O_TRUNC and fails outright if that file exists but is not writable by the current user
 	// (eg, left behind by a run with elevated privileges).
@@ -105,10 +109,10 @@ func DownloadAndApply(ctx context.Context, tag, exePath string) error {
 		return fmt.Errorf("failed to extract the binary from %s: %w", url, err)
 	}
 
-	// Best-effort cleanup of leftovers from an interrupted earlier update; CheckWritable does
-	// this too, but Apply must not trip over them when called without a pre-flight check.
+	// Best-effort cleanup of leftovers from an interrupted earlier update; EnsureReplaceable
+	// does this too, but Apply must not trip over them when called without a pre-flight check.
 	if err := removeStaleUpdateFiles(exePath); err != nil {
-		log.Debug().Msgf("%v", err)
+		log.Debug().Msg(err.Error())
 	}
 
 	// Atomically replace the running executable (rename-with-rollback; Windows-safe).

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -6,13 +6,70 @@ package version
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/creativeprojects/go-selfupdate/update"
+	"github.com/metaplay/cli/internal/pathutil"
+	"github.com/rs/zerolog/log"
 )
+
+// updateTempSuffixes are the temp files that update.Apply creates next to the target
+// executable while swapping the binary.
+var updateTempSuffixes = []string{".new", ".old"}
+
+// CheckWritable verifies that the executable at exePath can actually be replaced in place,
+// so that an unwritable install (a package-manager-managed or system-wide location) fails
+// fast instead of only after a download of tens of MB.
+//
+// It probes what update.Apply does: create a file in the install directory, then rename over
+// the target. It deliberately never opens the target for writing — on Windows a running
+// executable is locked against writes but can still be renamed, which is how the swap works.
+func CheckWritable(exePath string) error {
+	// Clear leftovers from an interrupted earlier update first: Apply opens .<name>.new with
+	// O_TRUNC and fails outright if that file exists but is not writable by the current user
+	// (eg, left behind by a run with elevated privileges).
+	if err := removeStaleUpdateFiles(exePath); err != nil {
+		return err
+	}
+
+	// Probe that files can be created in the install directory.
+	dir := filepath.Dir(exePath)
+	probe, err := os.CreateTemp(dir, ".metaplay-update-probe-*")
+	if err != nil {
+		return fmt.Errorf("cannot create files in %s: %w", pathutil.ForDisplay(dir), err)
+	}
+	_ = probe.Close()
+	_ = os.Remove(probe.Name())
+
+	// Probe that the existing executable may be renamed out of the way.
+	return checkReplaceable(exePath)
+}
+
+// removeStaleUpdateFiles deletes .<name>.new / .<name>.old files left next to exePath by an
+// interrupted earlier update. A leftover that cannot be removed is reported as an error,
+// because Apply would fail on it later anyway: it truncates .new, and on Windows renaming
+// the target to .old fails when .old already exists.
+func removeStaleUpdateFiles(exePath string) error {
+	dir, name := filepath.Split(exePath)
+	for _, suffix := range updateTempSuffixes {
+		path := filepath.Join(dir, "."+name+suffix)
+		err := os.Remove(path)
+		switch {
+		case err == nil:
+			log.Debug().Msgf("Removed %s left over from an earlier update", path)
+		case !errors.Is(err, fs.ErrNotExist):
+			return fmt.Errorf("failed to remove %s left over from an earlier update: %w", pathutil.ForDisplay(path), err)
+		}
+	}
+	return nil
+}
 
 // DownloadAndApply downloads the release archive for the given version from the GitHub
 // CDN (not the throttled api.github.com), extracts the 'metaplay' binary, and atomically
@@ -46,6 +103,12 @@ func DownloadAndApply(ctx context.Context, tag, exePath string) error {
 	binary, err := selfupdate.DecompressCommand(resp.Body, url, "metaplay", runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return fmt.Errorf("failed to extract the binary from %s: %w", url, err)
+	}
+
+	// Best-effort cleanup of leftovers from an interrupted earlier update; CheckWritable does
+	// this too, but Apply must not trip over them when called without a pre-flight check.
+	if err := removeStaleUpdateFiles(exePath); err != nil {
+		log.Debug().Msgf("%v", err)
 	}
 
 	// Atomically replace the running executable (rename-with-rollback; Windows-safe).

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -5,6 +5,7 @@
 package version
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,11 +22,11 @@ func writeExe(t *testing.T, dir string) string {
 	return exe
 }
 
-func TestCheckWritableAcceptsWritableInstall(t *testing.T) {
+func TestEnsureReplaceableAcceptsWritableInstall(t *testing.T) {
 	dir := t.TempDir()
 	exe := writeExe(t, dir)
 
-	require.NoError(t, CheckWritable(exe))
+	require.NoError(t, EnsureReplaceable(exe))
 
 	// The probe file must not be left behind.
 	entries, err := os.ReadDir(dir)
@@ -34,16 +35,17 @@ func TestCheckWritableAcceptsWritableInstall(t *testing.T) {
 	assert.Equal(t, "metaplay.exe", entries[0].Name())
 }
 
-func TestCheckWritableAcceptsRunningExecutable(t *testing.T) {
+func TestCheckReplaceableAcceptsRunningExecutable(t *testing.T) {
 	// Guards against the replaceability probe reporting a false negative for the executable
 	// of the running process, which is locked against writes on Windows but still renamable.
+	// Only meaningful on Windows, where checkReplaceable actually probes.
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
 	assert.NoError(t, checkReplaceable(exe))
 }
 
-func TestCheckWritableRemovesStaleUpdateFiles(t *testing.T) {
+func TestEnsureReplaceableRemovesStaleUpdateFiles(t *testing.T) {
 	dir := t.TempDir()
 	exe := writeExe(t, dir)
 
@@ -55,17 +57,38 @@ func TestCheckWritableRemovesStaleUpdateFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("leftover"), 0o644))
 	}
 
-	require.NoError(t, CheckWritable(exe))
+	require.NoError(t, EnsureReplaceable(exe))
 
 	for _, path := range stale {
 		assert.NoFileExists(t, path, "leftover from an earlier update should be removed")
 	}
 }
 
-func TestCheckWritableRejectsMissingDirectory(t *testing.T) {
+func TestEnsureReplaceableRejectsMissingDirectory(t *testing.T) {
 	exe := filepath.Join(t.TempDir(), "does-not-exist", "metaplay.exe")
 
-	assert.Error(t, CheckWritable(exe))
+	assert.Error(t, EnsureReplaceable(exe))
+}
+
+func TestRemoveStaleUpdateFilesReportsLockedLeftoverAsNonPermission(t *testing.T) {
+	// A leftover held open by another process must not be classified as a permission problem,
+	// or the caller renders an elevation hint that cannot help.
+	dir := t.TempDir()
+	exe := writeExe(t, dir)
+	stale := filepath.Join(dir, ".metaplay.exe.old")
+	require.NoError(t, os.WriteFile(stale, []byte("leftover"), 0o644))
+
+	// Holding our own handle is enough on Windows; on Unix an open file is still unlinkable,
+	// so there is nothing to assert there.
+	release, locked := lockFile(t, stale)
+	if !locked {
+		t.Skip("open files do not block removal on this platform")
+	}
+	defer release()
+
+	err := removeStaleUpdateFiles(exe)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, fs.ErrPermission)
 }
 
 func TestRemoveStaleUpdateFilesIgnoresMissingFiles(t *testing.T) {

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeExe creates a dummy executable in dir and returns its path.
+func writeExe(t *testing.T, dir string) string {
+	t.Helper()
+	exe := filepath.Join(dir, "metaplay.exe")
+	require.NoError(t, os.WriteFile(exe, []byte("binary"), 0o755))
+	return exe
+}
+
+func TestCheckWritableAcceptsWritableInstall(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeExe(t, dir)
+
+	require.NoError(t, CheckWritable(exe))
+
+	// The probe file must not be left behind.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "metaplay.exe", entries[0].Name())
+}
+
+func TestCheckWritableAcceptsRunningExecutable(t *testing.T) {
+	// Guards against the replaceability probe reporting a false negative for the executable
+	// of the running process, which is locked against writes on Windows but still renamable.
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	assert.NoError(t, checkReplaceable(exe))
+}
+
+func TestCheckWritableRemovesStaleUpdateFiles(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeExe(t, dir)
+
+	stale := []string{
+		filepath.Join(dir, ".metaplay.exe.new"),
+		filepath.Join(dir, ".metaplay.exe.old"),
+	}
+	for _, path := range stale {
+		require.NoError(t, os.WriteFile(path, []byte("leftover"), 0o644))
+	}
+
+	require.NoError(t, CheckWritable(exe))
+
+	for _, path := range stale {
+		assert.NoFileExists(t, path, "leftover from an earlier update should be removed")
+	}
+}
+
+func TestCheckWritableRejectsMissingDirectory(t *testing.T) {
+	exe := filepath.Join(t.TempDir(), "does-not-exist", "metaplay.exe")
+
+	assert.Error(t, CheckWritable(exe))
+}
+
+func TestRemoveStaleUpdateFilesIgnoresMissingFiles(t *testing.T) {
+	assert.NoError(t, removeStaleUpdateFiles(filepath.Join(t.TempDir(), "metaplay.exe")))
+}

--- a/internal/version/update_test.go
+++ b/internal/version/update_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,66 @@ func writeExe(t *testing.T, dir string) string {
 	exe := filepath.Join(dir, "metaplay.exe")
 	require.NoError(t, os.WriteFile(exe, []byte("binary"), 0o755))
 	return exe
+}
+
+// assertBlockedLeftover checks the contract both platforms must satisfy for a leftover that
+// cannot be removed. Getting this wrong is what made the CLI tell users to re-run elevated for
+// a file that no privilege level can delete, so it is asserted from both platform tests.
+func assertBlockedLeftover(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLeftoverInUse, "a blocked leftover must be reported as in-use")
+	assert.NotErrorIs(t, err, fs.ErrPermission,
+		"a blocked leftover must not look like an unwritable install, or the hint tells the user to elevate")
+}
+
+func TestUpdateTempPathsMatchTheLibraryNaming(t *testing.T) {
+	// update.Apply builds its temp files as filepath.Join(Dir(target), "."+Base(target)+suffix).
+	// If these drift apart the cleanup silently stops matching anything, so pin the shape —
+	// including the extended-length form that GetExecutablePath returns on Windows.
+	tests := []struct {
+		name     string
+		exe      string
+		expected []string
+	}{
+		{
+			name: "plain path",
+			exe:  filepath.Join("install", "metaplay.exe"),
+			expected: []string{
+				filepath.Join("install", ".metaplay.exe.new"),
+				filepath.Join("install", ".metaplay.exe.old"),
+			},
+		},
+		{
+			name: "no extension",
+			exe:  filepath.Join("bin", "metaplay"),
+			expected: []string{
+				filepath.Join("bin", ".metaplay.new"),
+				filepath.Join("bin", ".metaplay.old"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, updateTempPaths(tt.exe))
+		})
+	}
+
+	// The library uses Dir+Base where this uses Split; they must agree on every input shape.
+	for _, exe := range []string{
+		filepath.Join("install", "metaplay.exe"),
+		`\\?\C:\ProgramData\chocolatey\lib\metaplay\tools\metaplay.exe`,
+		`\\?\UNC\server\share\tools\metaplay.exe`,
+		"/usr/local/bin/metaplay",
+		"metaplay.exe",
+	} {
+		dir, base := filepath.Dir(exe), filepath.Base(exe)
+		assert.Equal(t,
+			filepath.Join(dir, "."+base+".new"),
+			updateTempPaths(exe)[0],
+			"Split-based and Dir/Base-based construction must agree for %q", exe)
+	}
 }
 
 func TestEnsureReplaceableAcceptsWritableInstall(t *testing.T) {
@@ -35,24 +96,12 @@ func TestEnsureReplaceableAcceptsWritableInstall(t *testing.T) {
 	assert.Equal(t, "metaplay.exe", entries[0].Name())
 }
 
-func TestCheckReplaceableAcceptsRunningExecutable(t *testing.T) {
-	// Guards against the replaceability probe reporting a false negative for the executable
-	// of the running process, which is locked against writes on Windows but still renamable.
-	// Only meaningful on Windows, where checkReplaceable actually probes.
-	exe, err := os.Executable()
-	require.NoError(t, err)
-
-	assert.NoError(t, checkReplaceable(exe))
-}
-
 func TestEnsureReplaceableRemovesStaleUpdateFiles(t *testing.T) {
 	dir := t.TempDir()
 	exe := writeExe(t, dir)
 
-	stale := []string{
-		filepath.Join(dir, ".metaplay.exe.new"),
-		filepath.Join(dir, ".metaplay.exe.old"),
-	}
+	stale := updateTempPaths(exe)
+	require.Len(t, stale, 2)
 	for _, path := range stale {
 		require.NoError(t, os.WriteFile(path, []byte("leftover"), 0o644))
 	}
@@ -67,30 +116,34 @@ func TestEnsureReplaceableRemovesStaleUpdateFiles(t *testing.T) {
 func TestEnsureReplaceableRejectsMissingDirectory(t *testing.T) {
 	exe := filepath.Join(t.TempDir(), "does-not-exist", "metaplay.exe")
 
-	assert.Error(t, EnsureReplaceable(exe))
-}
+	err := EnsureReplaceable(exe)
 
-func TestRemoveStaleUpdateFilesReportsLockedLeftoverAsNonPermission(t *testing.T) {
-	// A leftover held open by another process must not be classified as a permission problem,
-	// or the caller renders an elevation hint that cannot help.
-	dir := t.TempDir()
-	exe := writeExe(t, dir)
-	stale := filepath.Join(dir, ".metaplay.exe.old")
-	require.NoError(t, os.WriteFile(stale, []byte("leftover"), 0o644))
-
-	// Holding our own handle is enough on Windows; on Unix an open file is still unlinkable,
-	// so there is nothing to assert there.
-	release, locked := lockFile(t, stale)
-	if !locked {
-		t.Skip("open files do not block removal on this platform")
-	}
-	defer release()
-
-	err := removeStaleUpdateFiles(exe)
 	require.Error(t, err)
-	assert.NotErrorIs(t, err, fs.ErrPermission)
+	// Must not be mistaken for a busy leftover: that would suggest closing other processes.
+	assert.NotErrorIs(t, err, ErrLeftoverInUse)
 }
 
 func TestRemoveStaleUpdateFilesIgnoresMissingFiles(t *testing.T) {
 	assert.NoError(t, removeStaleUpdateFiles(filepath.Join(t.TempDir(), "metaplay.exe")))
+}
+
+func TestRemoveStaleUpdateFilesDoesNotRepeatThePath(t *testing.T) {
+	// The message names the path once, via ForDisplay. Wrapping the whole *fs.PathError would
+	// print it a second time, prefixed with \\?\ on Windows.
+	dir := t.TempDir()
+	exe := writeExe(t, dir)
+	leftover := updateTempPaths(exe)[1]
+	require.NoError(t, os.WriteFile(leftover, []byte("leftover"), 0o644))
+
+	restore, blocked := blockDeletion(t, dir, exe, leftover)
+	if !blocked {
+		t.Skip("cannot make a file undeletable in this environment")
+	}
+	defer restore()
+
+	err := removeStaleUpdateFiles(exe)
+	require.Error(t, err)
+	assertBlockedLeftover(t, err)
+	assert.Equal(t, 1, strings.Count(err.Error(), filepath.Base(leftover)),
+		"the leftover path should appear exactly once in %q", err.Error())
 }

--- a/internal/version/update_unix.go
+++ b/internal/version/update_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+// checkReplaceable is a no-op on Unix: renaming a file requires write permission on the
+// containing directory rather than on the file itself, which CheckWritable already probes
+// by creating a file there.
+func checkReplaceable(_ string) error {
+	return nil
+}

--- a/internal/version/update_unix.go
+++ b/internal/version/update_unix.go
@@ -7,8 +7,14 @@
 package version
 
 // checkReplaceable is a no-op on Unix: renaming a file requires write permission on the
-// containing directory rather than on the file itself, which CheckWritable already probes
+// containing directory rather than on the file itself, which EnsureReplaceable already probes
 // by creating a file there.
+//
+// That covers the common cases (an unwritable or read-only install directory) but not all of
+// them: a sticky-bit directory additionally requires owning the file, and an immutable file
+// (chattr +i, chflags schg) cannot be renamed at all. Those still fail in update.Apply, where
+// the EPERM surfaces as a permission error and draws the same hint — just after the download
+// rather than before it.
 func checkReplaceable(_ string) error {
 	return nil
 }

--- a/internal/version/update_unix_test.go
+++ b/internal/version/update_unix_test.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import "testing"
+
+// lockFile reports that it could not lock: on Unix an open file is still unlinkable, so there
+// is no equivalent of the Windows sharing violation to exercise.
+func lockFile(_ *testing.T, _ string) (func(), bool) {
+	return func() {}, false
+}

--- a/internal/version/update_unix_test.go
+++ b/internal/version/update_unix_test.go
@@ -6,10 +6,60 @@
 
 package version
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
 
-// lockFile reports that it could not lock: on Unix an open file is still unlinkable, so there
-// is no equivalent of the Windows sharing violation to exercise.
-func lockFile(_ *testing.T, _ string) (func(), bool) {
-	return func() {}, false
+	"github.com/stretchr/testify/require"
+)
+
+// blockDeletion drops write permission on the containing directory, which is what prevents
+// unlinking a file on Unix. Reports false when that does not actually block removal — running
+// as root, or a filesystem that ignores mode bits.
+func blockDeletion(t *testing.T, dir, _, _ string) (func(), bool) {
+	t.Helper()
+
+	if os.Geteuid() == 0 {
+		t.Log("running as root, directory permissions do not block unlink")
+		return func() {}, false
+	}
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	restore := func() { _ = os.Chmod(dir, info.Mode().Perm()) }
+
+	// A canary proves the restriction actually bites before the test relies on it.
+	canary := filepath.Join(dir, "canary")
+	require.NoError(t, os.WriteFile(canary, []byte("canary"), 0o644))
+	require.NoError(t, os.Chmod(dir, 0o500))
+
+	if err := os.Remove(canary); err == nil {
+		t.Log("removal is not blocked by directory permissions here")
+		restore()
+		return func() {}, false
+	}
+
+	// t.TempDir() cleanup needs the mode back; cleanups run in reverse registration order, and
+	// this one is registered after TempDir's, so it runs first.
+	t.Cleanup(restore)
+	return restore, true
+}
+
+func TestEnsureReplaceableReportsBlockedLeftoverAsInUse(t *testing.T) {
+	// On Unix a directory that blocks unlink also blocks create, so EnsureReplaceable fails at
+	// the directory probe. The classification contract is therefore asserted directly against
+	// removeStaleUpdateFiles; see the Windows test for the end-to-end path.
+	dir := t.TempDir()
+	exe := writeExe(t, dir)
+	leftover := updateTempPaths(exe)[1]
+	require.NoError(t, os.WriteFile(leftover, []byte("leftover"), 0o644))
+
+	restore, blocked := blockDeletion(t, dir, exe, leftover)
+	if !blocked {
+		t.Skip("cannot make a file undeletable in this environment")
+	}
+	defer restore()
+
+	assertBlockedLeftover(t, removeStaleUpdateFiles(exe))
 }

--- a/internal/version/update_windows.go
+++ b/internal/version/update_windows.go
@@ -7,9 +7,7 @@
 package version
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 
 	"github.com/metaplay/cli/internal/pathutil"
 	"golang.org/x/sys/windows"
@@ -29,7 +27,7 @@ func checkReplaceable(path string) error {
 		return err
 	}
 
-	// Share everything, so the probe never fails merely because the executable is running.
+	// Share everything so the probe cannot fail over a share-mode conflict with another handle.
 	handle, err := windows.CreateFile(
 		p,
 		windows.DELETE,
@@ -40,10 +38,9 @@ func checkReplaceable(path string) error {
 		0,
 	)
 	if err != nil {
-		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
-			// Normalize to fs.ErrPermission so callers can render a permission-specific hint.
-			return fmt.Errorf("cannot replace %s: %w", pathutil.ForDisplay(path), fs.ErrPermission)
-		}
+		// The errno is wrapped as-is: syscall.Errno already satisfies errors.Is for
+		// fs.ErrPermission (ERROR_ACCESS_DENIED) and fs.ErrNotExist, and keeping it preserves
+		// which failure it actually was.
 		return fmt.Errorf("cannot replace %s: %w", pathutil.ForDisplay(path), err)
 	}
 	_ = windows.CloseHandle(handle)

--- a/internal/version/update_windows.go
+++ b/internal/version/update_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+
+	"github.com/metaplay/cli/internal/pathutil"
+	"golang.org/x/sys/windows"
+)
+
+// checkReplaceable reports whether the current process holds the DELETE right on path, which
+// is what Windows requires to rename the file out of the way during the binary swap. The
+// install directory being writable is not enough: files there commonly inherit a read-only
+// ACE for BUILTIN\Users (eg, C:\ProgramData\chocolatey\lib), which permits creating new files
+// but not replacing existing ones.
+//
+// Opening a handle with DELETE access does not delete anything — that would require
+// FILE_FLAG_DELETE_ON_CLOSE — so this is a safe, non-destructive probe.
+func checkReplaceable(path string) error {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	// Share everything, so the probe never fails merely because the executable is running.
+	handle, err := windows.CreateFile(
+		p,
+		windows.DELETE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		0,
+		0,
+	)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			// Normalize to fs.ErrPermission so callers can render a permission-specific hint.
+			return fmt.Errorf("cannot replace %s: %w", pathutil.ForDisplay(path), fs.ErrPermission)
+		}
+		return fmt.Errorf("cannot replace %s: %w", pathutil.ForDisplay(path), err)
+	}
+	_ = windows.CloseHandle(handle)
+
+	return nil
+}

--- a/internal/version/update_windows_test.go
+++ b/internal/version/update_windows_test.go
@@ -14,52 +14,112 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/windows"
 )
 
-// lockFile opens path sharing reads only, which blocks removal on Windows the same way a
-// mapped executable image does.
-func lockFile(t *testing.T, path string) (func(), bool) {
+// chocolateyLikeRights is every right except delete (D) and delete-child (DC): files may be
+// created in the directory but existing ones may not be removed or renamed. This is the shape
+// of C:\ProgramData\chocolatey\lib, which is the install layout this whole check exists for.
+const chocolateyLikeRights = `:(OI)(CI)(RD,WD,AD,REA,WEA,X,RA,WA,S)`
+
+// restrictDirectory applies chocolateyLikeRights to dir and registers a cleanup that restores
+// full control. Reports false if icacls is unavailable or the filesystem ignores ACLs.
+func restrictDirectory(t *testing.T, dir string) bool {
 	t.Helper()
 
-	p, err := windows.UTF16PtrFromString(path)
-	require.NoError(t, err)
-
-	handle, err := windows.CreateFile(p, windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, 0, 0)
-	require.NoError(t, err)
-
-	return func() { _ = windows.CloseHandle(handle) }, true
-}
-
-func TestCheckReplaceableReportsPermissionDenied(t *testing.T) {
 	user := os.Getenv("USERNAME")
 	if user == "" {
-		t.Skip("USERNAME is not set")
+		t.Log("USERNAME is not set, cannot construct an ACL")
+		return false
 	}
 
-	// ACL the directory the way C:\ProgramData\chocolatey\lib is: every right except delete (D)
-	// and delete-child (DC), so files may be created but existing ones may not be replaced.
-	dir := t.TempDir()
-	out, err := exec.Command("icacls", dir, "/inheritance:r",
-		"/grant", user+":(OI)(CI)(RD,WD,AD,REA,WEA,X,RA,WA,S)").CombinedOutput()
+	out, err := exec.Command("icacls", dir, "/inheritance:r", "/grant", user+chocolateyLikeRights).CombinedOutput()
 	if err != nil {
-		t.Skipf("icacls failed: %v: %s", err, out)
+		t.Logf("icacls failed: %v: %s", err, out)
+		return false
 	}
 
-	// Restore full control before t.TempDir()'s cleanup runs — cleanups run in reverse order of
-	// registration — or the tree cannot be removed and the test fails during teardown.
+	// Must run before t.TempDir()'s own cleanup — cleanups run in reverse registration order —
+	// or the restricted tree cannot be removed and teardown fails with a confusing error.
 	t.Cleanup(func() {
-		_ = exec.Command("icacls", dir, "/grant", user+":(OI)(CI)F", "/t", "/c").Run()
+		if out, err := exec.Command("icacls", dir, "/grant", user+":(OI)(CI)F", "/t", "/c").CombinedOutput(); err != nil {
+			t.Errorf("failed to restore ACLs on %s, temp tree may leak: %v: %s", dir, err, out)
+		}
 	})
+	return true
+}
+
+// blockDeletion makes leftover undeletable while keeping exe replaceable, so the leftover path
+// can be exercised without tripping the earlier replaceability check.
+func blockDeletion(t *testing.T, dir, exe, _ string) (func(), bool) {
+	t.Helper()
+
+	if !restrictDirectory(t, dir) {
+		return func() {}, false
+	}
+
+	// Grant DELETE on the executable only, so checkReplaceable still passes for it.
+	user := os.Getenv("USERNAME")
+	if out, err := exec.Command("icacls", exe, "/grant", user+":(D,WDAC)").CombinedOutput(); err != nil {
+		t.Logf("icacls on the executable failed: %v: %s", err, out)
+		return func() {}, false
+	}
+	return func() {}, true
+}
+
+func TestCheckReplaceableAcceptsRunningExecutable(t *testing.T) {
+	// The probe must not report a false negative for the executable of the running process,
+	// which Windows locks against writes while still allowing a rename. This is why the probe
+	// asks for DELETE rather than write access.
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	assert.NoError(t, checkReplaceable(exe))
+}
+
+func TestCheckReplaceableRejectsUnreplaceableBinary(t *testing.T) {
+	dir := t.TempDir()
+	if !restrictDirectory(t, dir) {
+		t.Skip("cannot construct a restrictive ACL in this environment")
+	}
 
 	// Created after the ACL change so it inherits the restricted rights.
 	exe := writeExe(t, dir)
 
-	// The pre-flight must classify this as a permission problem: the whole hint selection in
-	// 'metaplay update cli' keys off fs.ErrPermission.
-	err = checkReplaceable(exe)
+	err := checkReplaceable(exe)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, fs.ErrPermission)
 
-	assert.ErrorIs(t, EnsureReplaceable(exe), fs.ErrPermission)
+	// EnsureReplaceable must surface this as the permission problem it is, and must not blame a
+	// leftover file — the directory probe alone would pass here, which is the whole point.
+	err = EnsureReplaceable(exe)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrPermission)
+	assert.NotErrorIs(t, err, ErrLeftoverInUse)
+}
+
+func TestCheckReplaceableReportsMissingFileAsNotExist(t *testing.T) {
+	// A vanished executable must not be reported as a permission problem.
+	err := checkReplaceable(writeExe(t, t.TempDir()) + ".missing")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.NotErrorIs(t, err, fs.ErrPermission)
+}
+
+func TestEnsureReplaceableReportsBlockedLeftoverAsInUse(t *testing.T) {
+	dir := t.TempDir()
+	exe := writeExe(t, dir)
+	leftover := updateTempPaths(exe)[1]
+	require.NoError(t, os.WriteFile(leftover, []byte("leftover"), 0o644))
+
+	restore, blocked := blockDeletion(t, dir, exe, leftover)
+	if !blocked {
+		t.Skip("cannot make a file undeletable in this environment")
+	}
+	defer restore()
+
+	// Removing the leftover fails with ERROR_ACCESS_DENIED here, the same errno a mapped
+	// running image produces. It must still be classified as in-use, not as an unwritable
+	// install, or the hint tells the user to elevate for something elevation cannot fix.
+	assertBlockedLeftover(t, EnsureReplaceable(exe))
 }

--- a/internal/version/update_windows_test.go
+++ b/internal/version/update_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+/*
+ * Copyright Metaplay. Licensed under the Apache-2.0 license.
+ */
+
+package version
+
+import (
+	"io/fs"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// lockFile opens path sharing reads only, which blocks removal on Windows the same way a
+// mapped executable image does.
+func lockFile(t *testing.T, path string) (func(), bool) {
+	t.Helper()
+
+	p, err := windows.UTF16PtrFromString(path)
+	require.NoError(t, err)
+
+	handle, err := windows.CreateFile(p, windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, 0, 0)
+	require.NoError(t, err)
+
+	return func() { _ = windows.CloseHandle(handle) }, true
+}
+
+func TestCheckReplaceableReportsPermissionDenied(t *testing.T) {
+	user := os.Getenv("USERNAME")
+	if user == "" {
+		t.Skip("USERNAME is not set")
+	}
+
+	// ACL the directory the way C:\ProgramData\chocolatey\lib is: every right except delete (D)
+	// and delete-child (DC), so files may be created but existing ones may not be replaced.
+	dir := t.TempDir()
+	out, err := exec.Command("icacls", dir, "/inheritance:r",
+		"/grant", user+":(OI)(CI)(RD,WD,AD,REA,WEA,X,RA,WA,S)").CombinedOutput()
+	if err != nil {
+		t.Skipf("icacls failed: %v: %s", err, out)
+	}
+
+	// Restore full control before t.TempDir()'s cleanup runs — cleanups run in reverse order of
+	// registration — or the tree cannot be removed and the test fails during teardown.
+	t.Cleanup(func() {
+		_ = exec.Command("icacls", dir, "/grant", user+":(OI)(CI)F", "/t", "/c").Run()
+	})
+
+	// Created after the ACL change so it inherits the restricted rights.
+	exe := writeExe(t, dir)
+
+	// The pre-flight must classify this as a permission problem: the whole hint selection in
+	// 'metaplay update cli' keys off fs.ErrPermission.
+	err = checkReplaceable(exe)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrPermission)
+
+	assert.ErrorIs(t, EnsureReplaceable(exe), fs.ErrPermission)
+}

--- a/internal/version/update_windows_test.go
+++ b/internal/version/update_windows_test.go
@@ -7,60 +7,119 @@
 package version
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// chocolateyLikeRights is every right except delete (D) and delete-child (DC): files may be
-// created in the directory but existing ones may not be removed or renamed. This is the shape
-// of C:\ProgramData\chocolatey\lib, which is the install layout this whole check exists for.
-const chocolateyLikeRights = `:(OI)(CI)(RD,WD,AD,REA,WEA,X,RA,WA,S)`
+// These tests reproduce the ACL shape of C:\ProgramData\chocolatey\lib, where files may be
+// created but existing ones may not be replaced.
+//
+// Deny ACEs are used rather than a restricted grant: CI runs as an elevated administrator, and
+// a grant-only restriction leaves the Administrators ACE in place so the restriction does not
+// bite. Deny ACEs are evaluated ahead of allows for every SID in the token. Even so, each setup
+// verifies the denial actually took effect and skips if it did not — a test of a permission
+// failure that silently starts passing is worse than one that is absent.
 
-// restrictDirectory applies chocolateyLikeRights to dir and registers a cleanup that restores
-// full control. Reports false if icacls is unavailable or the filesystem ignores ACLs.
-func restrictDirectory(t *testing.T, dir string) bool {
+// icaclsUser returns the account name to write ACEs for.
+func icaclsUser(t *testing.T) (string, bool) {
 	t.Helper()
-
 	user := os.Getenv("USERNAME")
 	if user == "" {
 		t.Log("USERNAME is not set, cannot construct an ACL")
+		return "", false
+	}
+	return user, true
+}
+
+// denyRights adds a deny ACE for the current user on path and registers its removal, which must
+// happen before t.TempDir()'s cleanup or the tree cannot be deleted. Cleanups run in reverse
+// registration order, so registering here is correct.
+func denyRights(t *testing.T, path, rights string) bool {
+	t.Helper()
+
+	user, ok := icaclsUser(t)
+	if !ok {
 		return false
 	}
 
-	out, err := exec.Command("icacls", dir, "/inheritance:r", "/grant", user+chocolateyLikeRights).CombinedOutput()
-	if err != nil {
-		t.Logf("icacls failed: %v: %s", err, out)
+	if out, err := exec.Command("icacls", path, "/deny", user+":("+rights+")").CombinedOutput(); err != nil {
+		t.Logf("icacls /deny %s on %s failed: %v: %s", rights, path, err, out)
 		return false
 	}
 
-	// Must run before t.TempDir()'s own cleanup — cleanups run in reverse registration order —
-	// or the restricted tree cannot be removed and teardown fails with a confusing error.
 	t.Cleanup(func() {
-		if out, err := exec.Command("icacls", dir, "/grant", user+":(OI)(CI)F", "/t", "/c").CombinedOutput(); err != nil {
-			t.Errorf("failed to restore ACLs on %s, temp tree may leak: %v: %s", dir, err, out)
+		// The probe below deliberately tries to delete files, so the target may be gone.
+		if _, statErr := os.Lstat(path); errors.Is(statErr, fs.ErrNotExist) {
+			return
+		}
+		if out, err := exec.Command("icacls", path, "/remove:d", user).CombinedOutput(); err != nil {
+			t.Errorf("failed to drop the deny ACE on %s, temp tree may leak: %v: %s", path, err, out)
 		}
 	})
 	return true
 }
 
-// blockDeletion makes leftover undeletable while keeping exe replaceable, so the leftover path
-// can be exercised without tripping the earlier replaceability check.
-func blockDeletion(t *testing.T, dir, exe, _ string) (func(), bool) {
+// deletionIsBlocked reports whether the deny ACEs actually prevent deletion here, by trying it
+// on a throwaway file rather than on the file the test cares about. The caller must already have
+// denied delete-child on dir: without that, the parent's rights permit deleting any file in it
+// regardless of the file's own DACL, and a per-file deny proves nothing.
+func deletionIsBlocked(t *testing.T, dir string) bool {
 	t.Helper()
 
-	if !restrictDirectory(t, dir) {
+	canary := filepath.Join(dir, "canary")
+	require.NoError(t, os.WriteFile(canary, []byte("canary"), 0o644))
+
+	if !denyRights(t, canary, "D") {
+		return false
+	}
+	if err := os.Remove(canary); err == nil {
+		t.Log("deny ACEs do not prevent deletion in this environment")
+		return false
+	}
+	return true
+}
+
+// makeUnreplaceable denies deletion of exe and delete-child on dir, so the executable cannot be
+// renamed out of the way while the directory still accepts new files.
+func makeUnreplaceable(t *testing.T, dir, exe string) bool {
+	t.Helper()
+
+	// Applied to the directory itself, not inherited, so files created in it stay deletable.
+	if !denyRights(t, dir, "DC") || !denyRights(t, exe, "D") {
+		return false
+	}
+	if err := checkReplaceable(exe); err == nil {
+		t.Log("the executable is still replaceable despite the deny ACEs")
+		return false
+	}
+	return true
+}
+
+// blockDeletion makes leftover undeletable while keeping exe replaceable, so the leftover path
+// can be exercised without tripping the earlier replaceability check.
+func blockDeletion(t *testing.T, dir, exe, leftover string) (func(), bool) {
+	t.Helper()
+
+	// Deny delete-child on the directory first, or the parent's rights alone would allow removing
+	// the leftover. The executable keeps its inherited DELETE, so it stays replaceable.
+	if !denyRights(t, dir, "DC") {
 		return func() {}, false
 	}
-
-	// Grant DELETE on the executable only, so checkReplaceable still passes for it.
-	user := os.Getenv("USERNAME")
-	if out, err := exec.Command("icacls", exe, "/grant", user+":(D,WDAC)").CombinedOutput(); err != nil {
-		t.Logf("icacls on the executable failed: %v: %s", err, out)
+	if !deletionIsBlocked(t, dir) {
+		return func() {}, false
+	}
+	if !denyRights(t, leftover, "D") {
+		return func() {}, false
+	}
+	if err := checkReplaceable(exe); err != nil {
+		t.Logf("the executable became unreplaceable, which is not the case under test: %v", err)
 		return func() {}, false
 	}
 	return func() {}, true
@@ -78,12 +137,11 @@ func TestCheckReplaceableAcceptsRunningExecutable(t *testing.T) {
 
 func TestCheckReplaceableRejectsUnreplaceableBinary(t *testing.T) {
 	dir := t.TempDir()
-	if !restrictDirectory(t, dir) {
-		t.Skip("cannot construct a restrictive ACL in this environment")
-	}
-
-	// Created after the ACL change so it inherits the restricted rights.
 	exe := writeExe(t, dir)
+
+	if !makeUnreplaceable(t, dir, exe) {
+		t.Skip("cannot make a binary unreplaceable in this environment")
+	}
 
 	err := checkReplaceable(exe)
 	require.Error(t, err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -68,7 +68,7 @@ func CheckVersion(ctx context.Context, stderrLogger *zerolog.Logger) {
 		// install): this runs on every command for prerelease builds, so it would otherwise
 		// re-download the whole archive each time only to fail at the swap. Checked before
 		// announcing the update so a skip stays quiet.
-		if err := CheckWritable(exe); err != nil {
+		if err := EnsureReplaceable(exe); err != nil {
 			log.Debug().Msgf("Auto-update skipped: %v", err)
 			return
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -59,15 +59,23 @@ func CheckVersion(ctx context.Context, stderrLogger *zerolog.Logger) {
 
 	// Auto-update prerelease builds (except in CI).
 	if usePrerelease && !envutil.IsCI() {
-		stderrLogger.Info().Msgf("Auto-updating CLI from %s to %s...",
-			styles.RenderError(AppVersion),
-			styles.RenderSuccess(latest),
-		)
 		exe, err := pathutil.GetExecutablePath()
 		if err != nil {
 			log.Debug().Msgf("Auto-update failed: could not determine executable path: %v", err)
 			return
 		}
+		// Skip the download when the binary cannot be replaced (eg, a package-manager-managed
+		// install): this runs on every command for prerelease builds, so it would otherwise
+		// re-download the whole archive each time only to fail at the swap. Checked before
+		// announcing the update so a skip stays quiet.
+		if err := CheckWritable(exe); err != nil {
+			log.Debug().Msgf("Auto-update skipped: %v", err)
+			return
+		}
+		stderrLogger.Info().Msgf("Auto-updating CLI from %s to %s...",
+			styles.RenderError(AppVersion),
+			styles.RenderSuccess(latest),
+		)
 		// Bound the background download: it runs on every command for prerelease builds, so a
 		// stalled connection must not hang the command indefinitely. Ctrl+C still interrupts via
 		// the command context; the timeout is generous enough for a large archive on a slow link.


### PR DESCRIPTION
## Problem

`metaplay update cli` on a Chocolatey install downloads the whole release archive and then fails, with a hint pointing at the network:

```
Downloading Metaplay CLI version 1.12.1...
Error: Failed to update the Metaplay CLI binary (failed to replace the executable: open
\\?\C:\ProgramData\chocolatey\lib\metaplay\tools\.metaplay.exe.new: Access is denied.)

Hint: Check your network connection, or download a release manually from ...
```

`C:\ProgramData\chocolatey\lib\metaplay\tools` grants `BUILTIN\Users` write with `ContainerInherit` only: new files may be created, existing ones may not be replaced. The swap can therefore never succeed there. The immediate error came from a stale `.metaplay.exe.new` left by an earlier attempt. Nothing about it was a network problem, and nothing surfaced until the download had already been paid for.

## Change

**A pre-flight check before the download** — `version.EnsureReplaceable`, in this order:

1. probe that the executable can be renamed aside — on Windows a `CreateFile(path, DELETE, …)` handle, closed immediately;
2. probe that files can be created in the install directory;
3. clear `.<name>.new` / `.<name>.old` left by an interrupted earlier update.

**Hints chosen from the cause** instead of assumed: a busy leftover, an unwritable install, or a fallback. Permission failures also list the install path and the platform's package-manager update commands.

**The same check on the prerelease auto-update path**, which runs on every command and previously re-downloaded the entire archive each time on an install it could never write to.

**A Windows CI job**, plus `pathutil.ForDisplay` to keep `\\?\` out of user-facing paths.

## Three things worth knowing when reading this

**The probe asks for DELETE, not write access.** A running executable is locked against writes on Windows but can still be renamed, which is exactly how the swap works — opening it for write reports a false negative. A directory-writability check alone is also insufficient: it *passes* in the Chocolatey case, which is the entire bug.

**A busy leftover cannot be classified by errno.** After every successful Windows swap, `update.Apply` leaves `.<name>.old` behind — it is the mapped image of the process that just performed the update, so `Apply` hides it rather than deleting it. Removing a mapped image fails with `ERROR_ACCESS_DENIED`, which Go maps to `fs.ErrPermission`, making it indistinguishable from an unwritable install. No privilege level can delete a mapped image, so an "elevate" hint is useless there. Such failures are reported as `version.ErrLeftoverInUse` and matched *ahead of* the permission check.

**The ordering is load-bearing.** The free, non-destructive probe runs first so that an install which can never self-update says so — rather than blaming a leftover that is only a symptom — and so nothing is created in a directory we cannot delete from. Otherwise every attempt leaks an undeletable probe file, once per command on the auto-update path.

## Unix

`checkReplaceable` is a no-op: renaming requires write permission on the containing directory rather than on the file, and the directory probe already covers that. Two cases it misses — a sticky-bit directory holding a file owned by someone else, and an immutable file (`chattr +i`, `chflags schg`) — pass the pre-flight and fail in `Apply` with `EPERM`, which maps to `fs.ErrPermission` and draws the same hint, just after the download instead of before it. Both confirmed by execution.

## Verification

- **Windows:** all three hint paths end to end against real ACLs, including a genuine mapped-image leftover; a Chocolatey-shaped directory leaves no probe files across repeated runs.
- **Linux** (`golang:1.26` container): full suite green as non-root; the permission-classification tests pass as uid 1000 and skip with a reason as root.
- **Mutation-checked:** dropping the probe, swallowing the cleanup error, inverting the hint selection, or classifying leftovers by errno each fail tests.
- `make` clean, `go vet` clean for windows/linux/darwin, CI green.

## Notes for the reviewer

- **The `windows-latest` job costs more** than the existing Ubicloud runner. Everything in `update_windows.go` and `pathutil/windows.go` is behind `//go:build windows`, so the Linux job never compiled it — deleting the probe body shipped green before this. Drop the job if the cost is not worth hand verification. Its ACL tests skip with a reason where a runner cannot express the required deny ACE, so it will not fail spuriously.
- **Deliberately not done: rename-aside.** `os.Rename` of a mapped image *does* succeed, so a busy leftover could be moved out of the way and the update made to work. It strands a ~70 MB orphan that only a later run reaps; closing one process is the cheaper ask.
- **Known gap:** Scoop and Homebrew install into user-writable locations, so they pass the pre-flight and get swapped in place, desyncing the package manager's bookkeeping. Pre-existing, worth a separate issue — and it means those two lines in the hint are effectively unreachable today.
