### PR TITLE
Modernize to current stdlib APIs

### DIFF
--- a/cmd/build_image.go
+++ b/cmd/build_image.go
@@ -622,7 +622,7 @@ func buildDockerImage(ctx context.Context, params buildDockerImageParams) error 
 	projectDotnetVersion := fmt.Sprintf("%d.%d", projectDotnetVersionSegments[0], projectDotnetVersionSegments[1])
 
 	// Resolve final docker build invocation
-	dockerArgs := append(
+	dockerArgs := slices.Concat(
 		buildEngineArgs,
 		[]string{
 			"--pull",
@@ -636,7 +636,7 @@ func buildDockerImage(ctx context.Context, params buildDockerImageParams) error 
 			"--build-arg", fmt.Sprintf("PROJECT_ID=%s", params.project.Config.ProjectHumanID),
 			"--build-arg", fmt.Sprintf("BUILD_NUMBER=%s", params.buildNumber),
 			"--build-arg", fmt.Sprintf("COMMIT_ID=%s", params.commitID),
-		}...,
+		},
 	)
 
 	// If target platform is specified, set it explicitly.

--- a/cmd/llm_docs_test.go
+++ b/cmd/llm_docs_test.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -277,7 +276,7 @@ func TestWrapLLMDocsError(t *testing.T) {
 func TestBearerCredentials(t *testing.T) {
 	t.Run("empty token returns no metadata", func(t *testing.T) {
 		c := bearerCredentials{}
-		md, err := c.GetRequestMetadata(context.Background())
+		md, err := c.GetRequestMetadata(t.Context())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -288,7 +287,7 @@ func TestBearerCredentials(t *testing.T) {
 
 	t.Run("non-empty token sets bearer header", func(t *testing.T) {
 		c := bearerCredentials{token: "abc123"}
-		md, err := c.GetRequestMetadata(context.Background())
+		md, err := c.GetRequestMetadata(t.Context())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/project_ops.go
+++ b/cmd/project_ops.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -38,18 +39,18 @@ func isDirectory(path string) bool {
 // Hidden directories (starting with a dot) are skipped.
 func findSubDirectory(name, rootPath string, predicateFunc func(path string, relPath string) (bool, error)) (string, error) {
 	var foundPath string
-	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(rootPath, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip non-directories.
-		if !info.IsDir() {
+		if !entry.IsDir() {
 			return nil
 		}
 
 		// Skip dot directories (eg, .git).
-		if strings.HasPrefix(info.Name(), ".") {
+		if strings.HasPrefix(entry.Name(), ".") {
 			// log.Debug().Msgf("Skip directory: %s", path)
 			return filepath.SkipDir
 		}

--- a/cmd/sdk_modification_check.go
+++ b/cmd/sdk_modification_check.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,18 +85,18 @@ func buildGitignoreMatcherForDir(rootDir string) *gitignoreMatcher {
 	matcher := &gitignoreMatcher{}
 
 	// Walk the directory tree to find all .gitignore files. The callback handles
-	// per-entry errors itself (returning nil to continue), so Walk never returns a
-	// non-nil error here; gitignore matching is best-effort, so discard it.
-	_ = filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+	// per-entry errors itself (returning nil to continue), so WalkDir never returns
+	// a non-nil error here; gitignore matching is best-effort, so discard it.
+	_ = filepath.WalkDir(rootDir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // Continue on errors
 		}
 
-		if info.IsDir() {
+		if entry.IsDir() {
 			return nil
 		}
 
-		if info.Name() == ".gitignore" {
+		if entry.Name() == ".gitignore" {
 			// Read the file content and use NewGitIgnoreFromReader
 			// This avoids issues with NewGitIgnore's base path handling
 			content, err := os.ReadFile(path)
@@ -520,13 +521,13 @@ func DetectSdkModificationsWithPatch(sdkRootDir string, sdkZipPath string) (*Sdk
 	var patchBuf bytes.Buffer
 
 	// Walk the local SDK directory - detect and generate diff in one pass
-	err = filepath.Walk(sdkRootDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(sdkRootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 

--- a/cmd/sdk_modification_check_test.go
+++ b/cmd/sdk_modification_check_test.go
@@ -13,11 +13,7 @@ import (
 
 func TestGitignoreMatching(t *testing.T) {
 	// Create a temporary directory structure that mimics MetaplaySDK
-	tmpDir, err := os.MkdirTemp("", "sdk-gitignore-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	// Create .gitignore at root with patterns similar to MetaplaySDK
 	gitignoreContent := `# Build results
@@ -101,11 +97,7 @@ node_modules/
 
 func TestGitignoreNestedFiles(t *testing.T) {
 	// Create a temporary directory with nested .gitignore files
-	tmpDir, err := os.MkdirTemp("", "sdk-nested-gitignore-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	// Root .gitignore
 	rootGitignore := `bin/
@@ -165,11 +157,7 @@ temp/
 
 func TestGitignoreEmptyDirectory(t *testing.T) {
 	// Create a temporary directory with no .gitignore files
-	tmpDir, err := os.MkdirTemp("", "sdk-no-gitignore-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	matcher := buildGitignoreMatcherForDir(tmpDir)
 

--- a/cmd/skills_install.go
+++ b/cmd/skills_install.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	clierrors "github.com/metaplay/cli/internal/errors"
@@ -196,12 +197,7 @@ func flagScopeToScope(flag string) *skillspkg.Scope {
 // containsStr is shared with skills_prompter.go (defined here for now to
 // avoid an extra file). Linear scan; targets are tiny.
 func containsStr(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, s)
 }
 
 func reportInstallActions(actions []skillspkg.InstallAction) {

--- a/cmd/update_sdk_test.go
+++ b/cmd/update_sdk_test.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -122,7 +124,7 @@ func TestGetUniqueMajorVersions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := getUniqueMajorVersions(tc.versions)
-			if !intSliceEqual(result, tc.expected) {
+			if !slices.Equal(result, tc.expected) {
 				t.Errorf("getUniqueMajorVersions() = %v, expected %v", result, tc.expected)
 			}
 		})
@@ -181,7 +183,7 @@ func TestSortVersionOptions(t *testing.T) {
 				result[i] = opt.label
 			}
 
-			if !stringSliceEqual(result, tc.expected) {
+			if !slices.Equal(result, tc.expected) {
 				t.Errorf("sortVersionOptions() = %v, expected %v", result, tc.expected)
 			}
 		})
@@ -232,7 +234,7 @@ func TestSortVersionInfos(t *testing.T) {
 				result[i] = v.Version
 			}
 
-			if !stringSliceEqual(result, tc.expected) {
+			if !slices.Equal(result, tc.expected) {
 				t.Errorf("sortVersionInfos() = %v, expected %v", result, tc.expected)
 			}
 		})
@@ -563,7 +565,7 @@ func TestResolveTargetVersion(t *testing.T) {
 			if tc.expected == "" {
 				if err == nil {
 					t.Errorf("resolveTargetVersion() expected error containing %q, got nil", tc.errorContains)
-				} else if tc.errorContains != "" && !containsSubstring(err.Error(), tc.errorContains) {
+				} else if tc.errorContains != "" && !strings.Contains(err.Error(), tc.errorContains) {
 					t.Errorf("resolveTargetVersion() error = %q, expected to contain %q", err.Error(), tc.errorContains)
 				}
 			} else {
@@ -577,44 +579,4 @@ func TestResolveTargetVersion(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper functions for test assertions
-
-func intSliceEqual(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func stringSliceEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > 0 && findSubstring(s, substr)))
-}
-
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/errors/cli_error.go
+++ b/internal/errors/cli_error.go
@@ -122,8 +122,7 @@ func WrapUsageError(cause error, message string) *CLIError {
 
 // IsUsageError checks if an error is a usage error (should show usage help).
 func IsUsageError(err error) bool {
-	var cliErr *CLIError
-	if errors.As(err, &cliErr) {
+	if cliErr, ok := errors.AsType[*CLIError](err); ok {
 		return cliErr.IsUsageError()
 	}
 	return false
@@ -131,8 +130,7 @@ func IsUsageError(err error) bool {
 
 // GetExitCode returns the appropriate exit code for an error.
 func GetExitCode(err error) int {
-	var cliErr *CLIError
-	if errors.As(err, &cliErr) {
+	if cliErr, ok := errors.AsType[*CLIError](err); ok {
 		return int(cliErr.Code)
 	}
 	return int(ExitRuntime) // Default to runtime error
@@ -140,9 +138,5 @@ func GetExitCode(err error) int {
 
 // AsCLIError attempts to extract a CLIError from an error chain.
 func AsCLIError(err error) (*CLIError, bool) {
-	var cliErr *CLIError
-	if errors.As(err, &cliErr) {
-		return cliErr, true
-	}
-	return nil, false
+	return errors.AsType[*CLIError](err)
 }

--- a/internal/errors/cli_error_test.go
+++ b/internal/errors/cli_error_test.go
@@ -221,10 +221,10 @@ func TestBuilderChaining(t *testing.T) {
 }
 
 func TestWrapContextErrors(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	deadlineCtx, deadlineCancel := context.WithTimeout(context.Background(), 0)
+	deadlineCtx, deadlineCancel := context.WithTimeout(t.Context(), 0)
 	defer deadlineCancel()
 	// Force the deadline to expire
 	<-deadlineCtx.Done()

--- a/internal/syncutil/parallel.go
+++ b/internal/syncutil/parallel.go
@@ -14,13 +14,11 @@ func ParallelMap[In, Out any](items []In, maxConcurrency int, fn func(In) Out) [
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxConcurrency)
 	for i, item := range items {
-		wg.Add(1)
 		sem <- struct{}{}
-		go func(idx int, val In) {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() { <-sem }()
-			results[idx] = fn(val)
-		}(i, item)
+			results[i] = fn(item)
+		})
 	}
 	wg.Wait()
 	return results

--- a/internal/tui/compact_list.go
+++ b/internal/tui/compact_list.go
@@ -496,10 +496,7 @@ func ChooseFromListDialogMultiline[TItem any](
 	rowsPerItem := 1 + maxDescLines
 	delegate := compactMultilineDelegate{rowsPerItem: rowsPerItem}
 	// Bubble list height: rowsPerItem*N + spacing*(N-1) + slack.
-	listHeight := rowsPerItem*len(items) + delegate.Spacing()*(len(items)-1) + 2
-	if listHeight > 30 {
-		listHeight = 30
-	}
+	listHeight := min(rowsPerItem*len(items)+delegate.Spacing()*(len(items)-1)+2, 30)
 	l := list.New(listItems, delegate, 0, listHeight)
 	l.SetShowTitle(false)
 	l.SetFilteringEnabled(false)

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -105,8 +105,7 @@ func removeStaleUpdateFiles(exePath string) error {
 // unwrapPathError reduces an *fs.PathError to its cause, so a message that already names the
 // path via ForDisplay does not also print the raw \\?\-prefixed one the PathError carries.
 func unwrapPathError(err error) error {
-	var pathErr *fs.PathError
-	if errors.As(err, &pathErr) {
+	if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
 		return pathErr.Err
 	}
 	return err

--- a/pkg/envapi/target_environment.go
+++ b/pkg/envapi/target_environment.go
@@ -295,7 +295,7 @@ func (target *TargetEnvironment) GetKubeConfigWithExecCredential(userID string) 
 		Clusters: []KubeConfigCluster{
 			{
 				Cluster: KubeConfigClusterData{
-					CertificateAuthorityData: base64.StdEncoding.EncodeToString(credentials.Spec.Cluster.CertificateAuthorityData[:]),
+					CertificateAuthorityData: base64.StdEncoding.EncodeToString(credentials.Spec.Cluster.CertificateAuthorityData),
 					Server:                   credentials.Spec.Cluster.Server,
 				},
 				Name: credentials.Spec.Cluster.Server,
@@ -336,7 +336,7 @@ func (target *TargetEnvironment) GetKubeConfigWithExecCredential(userID string) 
 	if err != nil {
 		return "", err
 	}
-	dump := string(kubeConfig[:])
+	dump := string(kubeConfig)
 	return dump, nil
 }
 

--- a/pkg/envapi/wait_server_ready.go
+++ b/pkg/envapi/wait_server_ready.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -144,8 +144,8 @@ func fetchGameServerShardSets(ctx context.Context, kubeCli *KubeClient, newGameS
 	}
 
 	// Sort the shard sets by name to ensure consistent order in output.
-	sort.Slice(ownedSets, func(i, j int) bool {
-		return ownedSets[i].Name < ownedSets[j].Name
+	slices.SortFunc(ownedSets, func(a, b appsv1.StatefulSet) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	log.Debug().Msgf("Found %d matching StatefulSets", len(ownedSets))
@@ -684,7 +684,7 @@ func waitForHTTPServerToRespond(ctx context.Context, output *tui.TaskOutput, url
 			return fmt.Errorf("timeout reached while waiting for %s to respond", url)
 		default:
 			// Create a new request with headers
-			req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 			if err != nil {
 				output.AppendLinef("Error creating request for %s: %v. Retrying...", url, err)
 				break

--- a/pkg/filesetwriter/filesetwriter.go
+++ b/pkg/filesetwriter/filesetwriter.go
@@ -343,7 +343,7 @@ func (p *Plan) WaitForWritable(ctx context.Context, collapseDirectories bool) er
 
 		if len(stillReadOnlySet) == 0 {
 			// All writable — clear the footer and return.
-			for range len(footer) {
+			for range footer {
 				fmt.Fprintf(os.Stderr, "\033[2K\n")
 			}
 			// Move back up past the blank lines we just wrote.

--- a/pkg/filesetwriter/filesetwriter_test.go
+++ b/pkg/filesetwriter/filesetwriter_test.go
@@ -1118,7 +1118,7 @@ func TestWaitForWritableNoReadOnlyFiles(t *testing.T) {
 	}
 
 	// No read-only files → should return nil immediately.
-	if err := p.WaitForWritable(context.Background(), false); err != nil {
+	if err := p.WaitForWritable(t.Context(), false); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 }
@@ -1135,7 +1135,7 @@ func TestWaitForWritableNonInteractiveErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := p.WaitForWritable(context.Background(), false)
+	err := p.WaitForWritable(t.Context(), false)
 	if err == nil {
 		t.Fatal("expected error for read-only files in non-interactive mode")
 	}
@@ -1157,7 +1157,7 @@ func TestWaitForWritableContextCancelled(t *testing.T) {
 	}
 
 	// Cancel context immediately so the wait loop exits.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	err := p.WaitForWritable(ctx, false)

--- a/pkg/kubeutil/file_copy_test.go
+++ b/pkg/kubeutil/file_copy_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -90,11 +91,7 @@ func TestResumableFileCopyWithSimulatedFailures(t *testing.T) {
 	expectedMD5Str := hex.EncodeToString(expectedMD5[:])
 
 	// Create temp directory for test
-	tmpDir, err := os.MkdirTemp("", "file_copy_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	destPath := filepath.Join(tmpDir, "test_output.bin")
 
@@ -123,6 +120,7 @@ func TestResumableFileCopyWithSimulatedFailures(t *testing.T) {
 
 		// Open file in appropriate mode
 		var destFile *os.File
+		var err error
 		if state.bytesTransferred > 0 {
 			destFile, err = os.OpenFile(destPath, os.O_WRONLY|os.O_APPEND, 0644)
 			if err != nil {
@@ -196,11 +194,7 @@ func TestProgressCalculation(t *testing.T) {
 
 func TestAppendModeFileWriting(t *testing.T) {
 	// Test that append mode correctly continues from previous write
-	tmpDir, err := os.MkdirTemp("", "append_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	destPath := filepath.Join(tmpDir, "append_test.bin")
 
@@ -228,18 +222,14 @@ func TestAppendModeFileWriting(t *testing.T) {
 		t.Fatalf("Failed to read file: %v", err)
 	}
 
-	expected := append(firstHalf, secondHalf...)
+	expected := slices.Concat(firstHalf, secondHalf)
 	if !bytes.Equal(content, expected) {
 		t.Errorf("Content mismatch:\nExpected: %s\nGot: %s", expected, content)
 	}
 }
 
 func TestMD5Calculation(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "md5_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	testPath := filepath.Join(tmpDir, "test.bin")
 	testData := []byte("Hello, World!")

--- a/pkg/metahttp/metahttp.go
+++ b/pkg/metahttp/metahttp.go
@@ -285,7 +285,7 @@ func Request[TResponse any](c *Client, method string, url string, body any, cont
 		rawBody := response.Body()
 		if len(rawBody) == 0 {
 			// Empty body is only valid when TResponse is any (interface{}); all other types require a response body.
-			if reflect.TypeOf((*TResponse)(nil)).Elem().Kind() != reflect.Interface {
+			if reflect.TypeFor[TResponse]().Kind() != reflect.Interface {
 				return result, fmt.Errorf("server returned an empty response body where JSON was expected")
 			}
 		} else {

--- a/pkg/metahttp/metahttp_test.go
+++ b/pkg/metahttp/metahttp_test.go
@@ -51,8 +51,8 @@ func TestRequest_HTTPError_400ParsedMessage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	var httpErr *HTTPError
-	if !errors.As(err, &httpErr) {
+	httpErr, ok := errors.AsType[*HTTPError](err)
+	if !ok {
 		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
 	}
 	if httpErr.StatusCode != http.StatusBadRequest {
@@ -78,8 +78,8 @@ func TestRequest_HTTPError_404(t *testing.T) {
 
 	type response struct{}
 	_, err := Get[response](newTestClient(server.URL), "/missing")
-	var httpErr *HTTPError
-	if !errors.As(err, &httpErr) {
+	httpErr, ok := errors.AsType[*HTTPError](err)
+	if !ok {
 		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
 	}
 	if httpErr.StatusCode != http.StatusNotFound {
@@ -99,8 +99,8 @@ func TestRequest_HTTPError_409(t *testing.T) {
 
 	type response struct{}
 	_, err := PostJSON[response](newTestClient(server.URL), "/snapshots", map[string]any{"shardIndex": 0})
-	var httpErr *HTTPError
-	if !errors.As(err, &httpErr) {
+	httpErr, ok := errors.AsType[*HTTPError](err)
+	if !ok {
 		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
 	}
 	if httpErr.StatusCode != http.StatusConflict {
@@ -123,8 +123,8 @@ func TestRequest_HTTPError_500_NonJSONBody(t *testing.T) {
 
 	type response struct{}
 	_, err := Get[response](newTestClient(server.URL), "/boom")
-	var httpErr *HTTPError
-	if !errors.As(err, &httpErr) {
+	httpErr, ok := errors.AsType[*HTTPError](err)
+	if !ok {
 		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
 	}
 	if httpErr.StatusCode != http.StatusInternalServerError {
@@ -144,8 +144,8 @@ func TestRequest_HTTPError_EmptyBody(t *testing.T) {
 
 	type response struct{}
 	_, err := Get[response](newTestClient(server.URL), "/nothing")
-	var httpErr *HTTPError
-	if !errors.As(err, &httpErr) {
+	httpErr, ok := errors.AsType[*HTTPError](err)
+	if !ok {
 		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
 	}
 	if httpErr.StatusCode != http.StatusBadGateway {

--- a/pkg/skills/install.go
+++ b/pkg/skills/install.go
@@ -6,12 +6,14 @@ package skills
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
+	"strings"
 )
 
 // Scope selects which AgentDir directory to install into.
@@ -152,11 +154,11 @@ func Install(opts InstallOptions) ([]InstallAction, error) {
 		}
 	}
 
-	sort.Slice(actions, func(i, j int) bool {
-		if actions[i].TargetID != actions[j].TargetID {
-			return actions[i].TargetID < actions[j].TargetID
-		}
-		return actions[i].SkillID < actions[j].SkillID
+	slices.SortFunc(actions, func(a, b InstallAction) int {
+		return cmp.Or(
+			strings.Compare(a.TargetID, b.TargetID),
+			strings.Compare(a.SkillID, b.SkillID),
+		)
 	})
 	return actions, nil
 }

--- a/pkg/skills/remove.go
+++ b/pkg/skills/remove.go
@@ -5,12 +5,14 @@
 package skills
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
+	"strings"
 )
 
 // RemoveStatus categorises the outcome of removing a single wrapper.
@@ -71,8 +73,8 @@ func Remove(opts RemoveOptions) ([]RemoveAction, error) {
 	// targets that share a path scan it once and the report attributes the
 	// removal to the first target, with the rest marked as shared.
 	type group struct {
-		baseDir  string
-		targets  []string
+		baseDir string
+		targets []string
 	}
 	var groups []group
 	groupIdx := map[string]int{}
@@ -124,11 +126,11 @@ func Remove(opts RemoveOptions) ([]RemoveAction, error) {
 		}
 	}
 
-	sort.Slice(actions, func(i, j int) bool {
-		if actions[i].TargetID != actions[j].TargetID {
-			return actions[i].TargetID < actions[j].TargetID
-		}
-		return actions[i].SkillID < actions[j].SkillID
+	slices.SortFunc(actions, func(a, b RemoveAction) int {
+		return cmp.Or(
+			strings.Compare(a.TargetID, b.TargetID),
+			strings.Compare(a.SkillID, b.SkillID),
+		)
 	})
 	return actions, nil
 }
@@ -154,9 +156,7 @@ func optsScopeDir(scope Scope, t AgentDir) string {
 // that have since been removed from the embedded set.
 func candidateSkillDirs(baseDir string, filter []string) ([]string, error) {
 	if len(filter) > 0 {
-		out := append([]string(nil), filter...)
-		sort.Strings(out)
-		return out, nil
+		return slices.Sorted(slices.Values(filter)), nil
 	}
 	if _, err := os.Stat(baseDir); errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
@@ -171,7 +171,7 @@ func candidateSkillDirs(baseDir string, filter []string) ([]string, error) {
 			ids = append(ids, e.Name())
 		}
 	}
-	sort.Strings(ids)
+	slices.Sort(ids)
 	return ids, nil
 }
 

--- a/pkg/skills/skill.go
+++ b/pkg/skills/skill.go
@@ -5,11 +5,12 @@
 package skills
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -59,7 +60,7 @@ func (s *Skill) SubSkillNames() []string {
 	for k := range s.SubSkills {
 		names = append(names, k)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 
@@ -85,7 +86,7 @@ func LoadAll(rootFS fs.FS) ([]*Skill, error) {
 		}
 		skills = append(skills, skill)
 	}
-	sort.Slice(skills, func(i, j int) bool { return skills[i].ID < skills[j].ID })
+	slices.SortFunc(skills, func(a, b *Skill) int { return strings.Compare(a.ID, b.ID) })
 	return skills, nil
 }
 
@@ -111,7 +112,7 @@ func loadSkill(rootFS fs.FS, id string) (*Skill, error) {
 		Frontmatter: fm,
 		Body:        body,
 		RawSKILL:    raw,
-		SubSkills:    map[string]*SubSkill{},
+		SubSkills:   map[string]*SubSkill{},
 	}
 
 	entries, err := fs.ReadDir(rootFS, id)
@@ -196,10 +197,9 @@ func Resolve(skills []*Skill, address string) ([]byte, error) {
 		}
 		return skill.RawSKILL, nil
 	}
-	candidates := make([]*Skill, len(skills))
-	copy(candidates, skills)
-	sort.Slice(candidates, func(i, j int) bool {
-		return len(candidates[i].ID) > len(candidates[j].ID)
+	candidates := slices.Clone(skills)
+	slices.SortFunc(candidates, func(a, b *Skill) int {
+		return cmp.Compare(len(b.ID), len(a.ID))
 	})
 	for _, skill := range candidates {
 		prefix := skill.ID + "-"

--- a/pkg/testutil/background_game_server.go
+++ b/pkg/testutil/background_game_server.go
@@ -150,7 +150,7 @@ func NewGameServer(opts GameServerOptions) *BackgroundGameServer {
 	}
 
 	defaultCmd = append(defaultCmd, "--Player:ForceFullDebugConfigForBots=false")
-	opts.Cmd = append(defaultCmd, opts.ExtraArgs...)
+	opts.Cmd = slices.Concat(defaultCmd, opts.ExtraArgs)
 
 	return &BackgroundGameServer{opts: opts}
 }

--- a/pkg/testutil/run_once_container.go
+++ b/pkg/testutil/run_once_container.go
@@ -206,9 +206,9 @@ func (r *RunOnceContainer) Run(ctx context.Context) (int, error) {
 		}
 	}
 
-	exitCode := int(state.ExitCode)
+	exitCode := state.ExitCode
 
-	r.exitCode = int(exitCode)
+	r.exitCode = exitCode
 	r.completed = true
 
 	log.Debug().Msgf("Container completed with exit code: %d", r.exitCode)


### PR DESCRIPTION
Starts from `go fix ./...` (Go 1.26) and then covers the modernizations that `go fix`'s fixer set does not reach. `go fix -diff ./...` is now a no-op, and staticcheck with all checks enabled reports no correctness or simplification findings.

Net **-73 lines** across 24 files. Each commit is self-contained and builds on its own.

## Commits

| Commit | What |
|---|---|
| Apply `go fix ./...` | slices.Contains, min(), reflect.TypeFor |
| Replace sort package with slices | 8 sites; `sort` import gone from `pkg/skills` and `pkg/envapi` |
| Use errors.AsType over errors.As | 9 sites (Go 1.26 API) |
| Walk directory trees with filepath.WalkDir | 3 sites; avoids an lstat per entry |
| Join slices with slices.Concat | 2 sites that could alias the first slice |
| Use WaitGroup.Go in ParallelMap | plus obsolete loop-var parameters |
| Modernize test helpers | `t.TempDir()`, `t.Context()`, `slices.Equal`, `strings.Contains` |
| Drop redundant conversions and slice expressions | `[:]`, `int()`, `for range len(x)` |

## Notes for review

**`slices.Concat` fixes latent aliasing.** `cmd/build_image.go`, `pkg/testutil/background_game_server.go` and `pkg/kubeutil/file_copy_test.go` each did `append(x, y...)` and assigned the result somewhere other than `x`, so a spare-capacity `x` would be written through. Benign at the current call sites, but a trap for the next one.

**`SubSkillNames` deliberately keeps its explicit loop.** The natural form is `slices.Sorted(maps.Keys(s.SubSkills))`, but that makes staticcheck emit four SA5011 "possible nil pointer dereference" false positives in `pkg/skills/{skill,embedded}_test.go` against `x := FindByID(...); if x == nil { t.Fatal(...) }; x.Field` — a pattern it accepts today. It only fires when that call and `slices.SortFunc` are both present in the package, and it flags `gamma` while ignoring the identical `alpha` a few lines above, so it is an analyzer artifact around generic/iterator instantiation rather than a real defect. Using `for k := range m` + `slices.Sort` still removes the `sort` import and keeps `make lint` green, without adding `//nolint` to correct tests.

**Two sites left on the old API on purpose.** `TestErrorsAs` keeps `errors.As` because verifying that interop is the point of the test, and `pkg/skills/example_test.go` keeps `os.MkdirTemp` because an `Example` function has no `*testing.T` to call `t.TempDir()` on.

## Verification

- `make` (lint + build) clean
- `go test ./...` fully passing
- `go fix -diff ./...` and `go mod tidy` both no-ops
- every commit builds independently