### PR TITLE
Remove dead code and enforce gofmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,15 @@
 version: "2"
 
-# Use the standard linter set (errcheck, govet, ineffassign, staticcheck, unused).
-linters:
-  default: standard
+# The default linter set (errcheck, govet, ineffassign, staticcheck, unused)
+# is unchanged. This file exists to enforce gofmt: CI runs golangci-lint
+# rather than 'make lint', so nothing was catching formatting drift.
+formatters:
+  enable:
+    - gofmt
 
-# Report every issue; don't truncate the output so CI surfaces all problems.
 issues:
+  # Report every occurrence. The defaults (50 per linter, 3 per distinct
+  # message) silently truncate, which reads as "that's all of them" when
+  # it isn't -- the gofmt check hid a file on its first run.
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ clean:
 fix:
 	go mod tidy
 	go fix ./...
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) fmt
 	go build -o dist/metaplay$(BIN_SUFFIX) .
 
 test:

--- a/cmd/database_export_archive.go
+++ b/cmd/database_export_archive.go
@@ -205,10 +205,10 @@ func (o *databaseExportArchiveOpts) Run(cmd *cobra.Command) error {
 
 // DatabaseArchiveMetadata contains information about the database export
 type DatabaseArchiveMetadata struct {
-	Version      int       `json:"version"`
-	Environment  string    `json:"environment"`
-	DatabaseName string    `json:"database_name"`
-	NumShards    int       `json:"num_shards"`
+	Version      int    `json:"version"`
+	Environment  string `json:"environment"`
+	DatabaseName string `json:"database_name"`
+	NumShards    int    `json:"num_shards"`
 	// MasterVersion is the database schema master version captured at export time (from the MetaInfo
 	// table). It is omitted for archives where it could not be determined (e.g. older archives or a
 	// fresh database). Shown by 'import-archive' so the user can keep the deployed server's version in sync.

--- a/cmd/database_import_archive.go
+++ b/cmd/database_import_archive.go
@@ -295,7 +295,7 @@ func (o *databaseImportArchiveOpts) importDatabaseContents(ctx context.Context, 
 	log.Debug().Msg("Apply schema to all shards")
 	for _, targetShard := range dbShards {
 		log.Debug().Int("shard_index", targetShard.ShardIndex).Str("database_name", targetShard.DatabaseName).Msg("Apply schema to shard")
-		err := o.importDatabaseSchema(ctx, schemaFile, kubeCli, podName, debugContainerName, targetShard)
+		err := o.importSQLFromZip(ctx, "schema", schemaFile, kubeCli, podName, debugContainerName, targetShard)
 		if err != nil {
 			return fmt.Errorf("failed to apply schema to shard %d: %v", targetShard.ShardIndex, err)
 		}
@@ -308,7 +308,7 @@ func (o *databaseImportArchiveOpts) importDatabaseContents(ctx context.Context, 
 		targetShard := dbShards[i]
 		log.Debug().Int("shard_index", targetShard.ShardIndex).Str("database_name", targetShard.DatabaseName).Msg("Start shard data import")
 
-		err := o.importDatabaseShardData(ctx, shardFile, kubeCli, podName, debugContainerName, targetShard)
+		err := o.importSQLFromZip(ctx, "shard", shardFile, kubeCli, podName, debugContainerName, targetShard)
 		if err != nil {
 			return fmt.Errorf("failed to import shard %d data: %v", targetShard.ShardIndex, err)
 		}
@@ -405,25 +405,25 @@ func (o *databaseImportArchiveOpts) openAndValidateZipFile() (*zip.ReadCloser, *
 	return zipReader, &metadata, schemaFile, shardFiles, nil
 }
 
-// Helper function to import database schema to a single shard
-func (o *databaseImportArchiveOpts) importDatabaseSchema(ctx context.Context, schemaFile *zip.File, kubeCli *envapi.KubeClient, podName, debugContainerName string, targetShard kubeutil.DatabaseShardConfig) error {
-	// Open schema file from zip
-	schemaReader, err := schemaFile.Open()
+// importSQLFromZip streams one SQL entry out of the archive into mariadb on the
+// target shard, running the client inside the debug container so the data never
+// lands on local disk. kind ("schema" or "shard") only selects wording for the
+// logs and errors; the two flows are otherwise identical.
+func (o *databaseImportArchiveOpts) importSQLFromZip(ctx context.Context, kind string, file *zip.File, kubeCli *envapi.KubeClient, podName, debugContainerName string, targetShard kubeutil.DatabaseShardConfig) error {
+	reader, err := file.Open()
 	if err != nil {
-		return fmt.Errorf("failed to open schema file %s: %v", schemaFile.Name, err)
+		return fmt.Errorf("failed to open %s file %s: %v", kind, file.Name, err)
 	}
-	defer func() { _ = schemaReader.Close() }()
+	defer func() { _ = reader.Close() }()
 
-	// Build mariadb import command for schema
 	importCmd := fmt.Sprintf("mariadb -h %s -u %s -p%s %s",
 		targetShard.ReadWriteHost, // Use primary host for writes
 		targetShard.UserId,
 		targetShard.Password,
 		targetShard.DatabaseName)
 
-	log.Debug().Str("host", targetShard.ReadWriteHost).Str("database", targetShard.DatabaseName).Msg("Executing schema import command")
+	log.Debug().Str("host", targetShard.ReadWriteHost).Str("database", targetShard.DatabaseName).Msgf("Executing %s import command", kind)
 
-	// Execute mariadb import command and stream schema directly
 	req := kubeCli.Clientset.CoreV1().
 		RESTClient().
 		Post().
@@ -441,66 +441,15 @@ func (o *databaseImportArchiveOpts) importDatabaseSchema(ctx context.Context, sc
 		}, scheme.ParameterCodec)
 
 	ioStreams := IOStreams{
-		In:     schemaReader, // Stream schema directly from zip
+		In:     reader, // Stream the SQL straight from the zip entry
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	}
 
-	err = execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false)
-	if err != nil {
-		return fmt.Errorf("schema import failed: %v", err)
+	if err := execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false); err != nil {
+		return fmt.Errorf("%s import failed: %v", kind, err)
 	}
-	log.Debug().Str("schema_file", schemaFile.Name).Msg("Schema imported successfully")
-
-	return nil
-}
-
-// Helper function to import shard data by streaming compressed data to remote execution
-func (o *databaseImportArchiveOpts) importDatabaseShardData(ctx context.Context, shardFile *zip.File, kubeCli *envapi.KubeClient, podName, debugContainerName string, targetShard kubeutil.DatabaseShardConfig) error {
-	// Open shard file from zip
-	shardReader, err := shardFile.Open()
-	if err != nil {
-		return fmt.Errorf("failed to open shard file %s: %v", shardFile.Name, err)
-	}
-	defer func() { _ = shardReader.Close() }()
-
-	// Build mariadb import command for uncompressed SQL
-	importCmd := fmt.Sprintf("mariadb -h %s -u %s -p%s %s",
-		targetShard.ReadWriteHost, // Use primary host for writes
-		targetShard.UserId,
-		targetShard.Password,
-		targetShard.DatabaseName)
-
-	log.Debug().Str("host", targetShard.ReadWriteHost).Str("database", targetShard.DatabaseName).Msg("Executing mariadb import command")
-
-	// Execute mariadb import command and stream uncompressed SQL data directly
-	req := kubeCli.Clientset.CoreV1().
-		RESTClient().
-		Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(kubeCli.Namespace).
-		SubResource("exec").
-		VersionedParams(&corev1.PodExecOptions{
-			Container: debugContainerName,
-			Command:   []string{"/bin/sh", "-c", importCmd},
-			Stdin:     true,
-			Stdout:    true,
-			Stderr:    true,
-			TTY:       false,
-		}, scheme.ParameterCodec)
-
-	ioStreams := IOStreams{
-		In:     shardReader, // Stream uncompressed SQL data directly from zip
-		Out:    os.Stdout,
-		ErrOut: os.Stderr,
-	}
-
-	err = execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false)
-	if err != nil {
-		return fmt.Errorf("database import failed: %v", err)
-	}
-	log.Debug().Str("shard_file", shardFile.Name).Msg("Shard imported successfully")
+	log.Debug().Str(kind+"_file", file.Name).Msgf("%s imported successfully", kind)
 
 	return nil
 }

--- a/cmd/database_reset.go
+++ b/cmd/database_reset.go
@@ -208,10 +208,7 @@ func (o *databaseResetOpts) Run(cmd *cobra.Command) error {
 	log.Debug().Str("environment", o.argEnvironment).Msg("Starting database reset process")
 
 	// Get table names from all shards once at the beginning
-	allShardTables, err := o.getAllShardTables(cmd.Context(), kubeCli, podName, "debug", shards)
-	if err != nil {
-		return fmt.Errorf("failed to get table information from shards: %w", err)
-	}
+	allShardTables := o.getAllShardTables(cmd.Context(), kubeCli, podName, "debug", shards)
 
 	// Check if database is already empty
 	totalTables := 0
@@ -238,7 +235,7 @@ func (o *databaseResetOpts) Run(cmd *cobra.Command) error {
 }
 
 // getAllShardTables gets table names from all shards once and returns a map of shard index to table names
-func (o *databaseResetOpts) getAllShardTables(ctx context.Context, kubeCli *envapi.KubeClient, podName, debugContainerName string, shards []kubeutil.DatabaseShardConfig) (map[int][]string, error) {
+func (o *databaseResetOpts) getAllShardTables(ctx context.Context, kubeCli *envapi.KubeClient, podName, debugContainerName string, shards []kubeutil.DatabaseShardConfig) map[int][]string {
 	allShardTables := make(map[int][]string)
 
 	for _, shard := range shards {
@@ -254,7 +251,7 @@ func (o *databaseResetOpts) getAllShardTables(ctx context.Context, kubeCli *enva
 		log.Debug().Int("shard_index", shard.ShardIndex).Int("table_count", len(tables)).Msg("Retrieved table names from shard")
 	}
 
-	return allShardTables, nil
+	return allShardTables
 }
 
 // Reset the database in the target environment. Uses the same sequence as the game server

--- a/cmd/debug_collect_heap_dump.go
+++ b/cmd/debug_collect_heap_dump.go
@@ -198,10 +198,7 @@ func (o *debugCollectHeapDumpOpts) Run(cmd *cobra.Command) error {
 	runner := tui.NewTaskRunner()
 
 	// Collect and retrieve heap dump using task runner
-	err = o.collectAndRetrieveHeapDump(cmd.Context(), kubeCli, pod.Name, debugContainerName, processInfo, runner)
-	if err != nil {
-		return err
-	}
+	o.collectAndRetrieveHeapDump(cmd.Context(), kubeCli, pod.Name, debugContainerName, processInfo, runner)
 
 	// Run the tasks
 	if err := runner.Run(); err != nil {
@@ -214,7 +211,7 @@ func (o *debugCollectHeapDumpOpts) Run(cmd *cobra.Command) error {
 }
 
 // Helper function to collect and retrieve heap dump using task runner
-func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Context, kubeCli *envapi.KubeClient, podName, debugContainerName string, processInfo *kubeutil.ServerProcessInfo, runner *tui.TaskRunner) error {
+func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Context, kubeCli *envapi.KubeClient, podName, debugContainerName string, processInfo *kubeutil.ServerProcessInfo, runner *tui.TaskRunner) {
 	// Set healthz probe to success mode
 	runner.AddTask("Disable health checks", func(output *tui.TaskOutput) error {
 		_, _, err := kubeutil.ExecInDebugContainer(ctx, kubeCli, podName, debugContainerName,
@@ -294,8 +291,6 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 		}
 		return nil
 	})
-
-	return nil
 }
 
 // formatDuration converts a duration in seconds to a human-readable string

--- a/cmd/debug_collect_heap_dump.go
+++ b/cmd/debug_collect_heap_dump.go
@@ -295,18 +295,14 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 
 // formatDuration converts a duration in seconds to a human-readable string
 func formatDuration(seconds int) string {
-	d := time.Duration(seconds) * time.Second
-	h := d / time.Hour
-	d -= h * time.Hour
-	m := d / time.Minute
-	d -= m * time.Minute
-	s := d / time.Second
+	h, m, s := seconds/3600, seconds/60%60, seconds%60
 
-	if h > 0 {
+	switch {
+	case h > 0:
 		return fmt.Sprintf("%dh %dm %ds", h, m, s)
-	} else if m > 0 {
+	case m > 0:
 		return fmt.Sprintf("%dm %ds", m, s)
-	} else {
+	default:
 		return fmt.Sprintf("%ds", s)
 	}
 }

--- a/cmd/get_server_info.go
+++ b/cmd/get_server_info.go
@@ -216,10 +216,7 @@ func (o *getServerInfoOpts) gatherDeployedServerInfo(ctx context.Context, target
 	var helmInfo *helmReleaseInfo
 	var imageInfo *deploymentImageInfo
 	if existingRelease != nil {
-		helmInfo, err = o.getHelmReleaseInfo(existingRelease)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get Helm release info: %w", err)
-		}
+		helmInfo = o.getHelmReleaseInfo(existingRelease)
 
 		imageInfo, err = o.getImageInfo(ctx, targetEnv, existingRelease)
 		if err != nil {
@@ -236,7 +233,7 @@ func (o *getServerInfoOpts) gatherDeployedServerInfo(ctx context.Context, target
 }
 
 // Extract the Helm release information from a release object into a simpler info class.
-func (o *getServerInfoOpts) getHelmReleaseInfo(releaseInfo *release.Release) (*helmReleaseInfo, error) {
+func (o *getServerInfoOpts) getHelmReleaseInfo(releaseInfo *release.Release) *helmReleaseInfo {
 	helmInfo := &helmReleaseInfo{
 		Name:         releaseInfo.Name,
 		Status:       releaseInfo.Info.Status.String(),
@@ -250,7 +247,7 @@ func (o *getServerInfoOpts) getHelmReleaseInfo(releaseInfo *release.Release) (*h
 		helmInfo.ChartVersion = releaseInfo.Chart.Metadata.Version
 	}
 
-	return helmInfo, nil
+	return helmInfo
 }
 
 // Extract information about the docker image used in the game server deployment.

--- a/cmd/init_project.go
+++ b/cmd/init_project.go
@@ -221,7 +221,7 @@ func (o *initProjectOpts) Run(cmd *cobra.Command) error {
 
 		// Validate SDK version.
 		// \todo Enforce version when using --sdk-source?
-		_, err = parseAndValidateSdkVersion(sdkVersionInfo.Version)
+		err = parseAndValidateSdkVersion(sdkVersionInfo.Version)
 		if err != nil {
 			return err
 		}
@@ -454,25 +454,25 @@ func ensureContractAccepted(ctx context.Context, portalClient *portalapi.Client,
 }
 
 // Parse an SDK version and validate that it's compatible with this CLI version.
-func parseAndValidateSdkVersion(versionStr string) (*version.Version, error) {
+func parseAndValidateSdkVersion(versionStr string) error {
 	// Validate the selected SDK version.
 	vsn, err := version.NewVersion(versionStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid SDK version string '%s': %w", versionStr, err)
+		return fmt.Errorf("invalid SDK version string '%s': %w", versionStr, err)
 	}
 
 	// Check that the SDK version is the minimum supported by the CLI.
 	if vsn.LessThan(metaproj.OldestSupportedSdkVersion) {
-		return nil, clierrors.Newf("SDK version %s is too old", versionStr).
+		return clierrors.Newf("SDK version %s is too old", versionStr).
 			WithDetails(fmt.Sprintf("Minimum supported version is %s", metaproj.OldestSupportedSdkVersion)).
 			WithSuggestion("Update Metaplay SDK to a more recent version (or use the legacy AuthCLI if you must use an older version)")
 	}
 
 	// Must not be newer than the latest supported version.
 	if vsn.GreaterThan(latestSupportedSdkVersion) {
-		return nil, clierrors.Newf("SDK version %s is not supported by this CLI version", versionStr).
+		return clierrors.Newf("SDK version %s is not supported by this CLI version", versionStr).
 			WithSuggestion("Upgrade the CLI with 'metaplay update cli'")
 	}
 
-	return vsn, nil
+	return nil
 }

--- a/cmd/init_sdk.go
+++ b/cmd/init_sdk.go
@@ -111,7 +111,7 @@ func (o *initSdkOpts) Run(cmd *cobra.Command) error {
 	}
 
 	// Ensure that the SDK version is valid and supported.
-	_, err = parseAndValidateSdkVersion(sdkVersionInfo.Version)
+	err = parseAndValidateSdkVersion(sdkVersionInfo.Version)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (o *initSdkOpts) Run(cmd *cobra.Command) error {
 
 	// Download and extract the SDK.
 	// Pass the parent directory since the extractor creates MetaplaySDK/ within it
-	if _, err := downloadAndExtractSdk(tokenSet, parentDir, sdkVersionInfo); err != nil {
+	if err := downloadAndExtractSdk(tokenSet, parentDir, sdkVersionInfo); err != nil {
 		return err
 	}
 

--- a/cmd/project_ops.go
+++ b/cmd/project_ops.go
@@ -216,7 +216,7 @@ func downloadSdkWithProgress(tokenSet *auth.TokenSet, sdkVersionInfo *portalapi.
 
 // Download the SDK (into the OS temp directory) and extract to the targetProjectPath.
 // Downloads the version specified by versionInfo.
-func downloadAndExtractSdk(tokenSet *auth.TokenSet, targetProjectPath string, versionInfo *portalapi.SdkVersionInfo) (*metaproj.MetaplayVersionMetadata, error) {
+func downloadAndExtractSdk(tokenSet *auth.TokenSet, targetProjectPath string, versionInfo *portalapi.SdkVersionInfo) error {
 	// Download the SDK archive to temp directory.
 	tmpDir := os.TempDir()
 	portalClient := portalapi.NewClient(tokenSet)
@@ -227,7 +227,7 @@ func downloadAndExtractSdk(tokenSet *auth.TokenSet, targetProjectPath string, ve
 	// Download the specific version
 	sdkZipPath, err = portalClient.DownloadSdkByVersionID(tmpDir, versionInfo.ID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download SDK version '%s': %w", versionInfo.Version, err)
+		return fmt.Errorf("failed to download SDK version '%s': %w", versionInfo.Version, err)
 	}
 	log.Debug().Msgf("Downloaded SDK version '%s' (ID: %s)", versionInfo.Version, versionInfo.ID)
 	defer func() { _ = os.Remove(sdkZipPath) }()
@@ -235,16 +235,16 @@ func downloadAndExtractSdk(tokenSet *auth.TokenSet, targetProjectPath string, ve
 	// Validate the SDK archive file.
 	sdkMetadata, err := validateSdkZipFile(sdkZipPath)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Metaplay SDK archive: %v", err)
+		return fmt.Errorf("invalid Metaplay SDK archive: %v", err)
 	}
 	log.Debug().Msgf("Use downloaded SDK archive: %s (v%s)", sdkZipPath, sdkMetadata.SdkVersion)
 
 	// Extract SDK into target directory.
 	if err := extractSdkFromZip(targetProjectPath, sdkZipPath); err != nil {
-		return nil, fmt.Errorf("failed to extract SDK archive: %w", err)
+		return fmt.Errorf("failed to extract SDK archive: %w", err)
 	}
 
-	return sdkMetadata, nil
+	return nil
 }
 
 func resolveSdkSource(targetProjectPath, sdkSource string) (string, *metaproj.MetaplayVersionMetadata, error) {

--- a/cmd/sdk_modification_check_test.go
+++ b/cmd/sdk_modification_check_test.go
@@ -178,20 +178,6 @@ func TestGitignoreEmptyDirectory(t *testing.T) {
 	}
 }
 
-// containsString checks if a string contains a substring
-func containsString(s, substr string) bool {
-	return len(substr) > 0 && len(s) >= len(substr) && findSubstr(s, substr)
-}
-
-func findSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
 func TestGenerateUnifiedDiff_NewFile(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -224,22 +210,22 @@ func TestGenerateUnifiedDiff_NewFile(t *testing.T) {
 			result := generateUnifiedDiff(tc.path, nil, []byte(tc.newContent), true, false)
 
 			// Check for git diff header
-			if !containsString(result, "diff --git a/"+tc.path+" b/"+tc.path) {
+			if !strings.Contains(result, "diff --git a/"+tc.path+" b/"+tc.path) {
 				t.Errorf("missing diff header, got:\n%s", result)
 			}
 
 			// Check for new file marker
-			if !containsString(result, "new file mode 100644") {
+			if !strings.Contains(result, "new file mode 100644") {
 				t.Errorf("missing 'new file mode' marker, got:\n%s", result)
 			}
 
 			// Check for /dev/null in old file
-			if !containsString(result, "--- /dev/null") {
+			if !strings.Contains(result, "--- /dev/null") {
 				t.Errorf("missing '--- /dev/null', got:\n%s", result)
 			}
 
 			// Check hunk header format (must be -0,0 for new files)
-			if !containsString(result, tc.wantHunk) {
+			if !strings.Contains(result, tc.wantHunk) {
 				t.Errorf("expected hunk header %q, got:\n%s", tc.wantHunk, result)
 			}
 		})
@@ -272,17 +258,17 @@ func TestGenerateUnifiedDiff_DeletedFile(t *testing.T) {
 			result := generateUnifiedDiff(tc.path, []byte(tc.oldContent), nil, false, true)
 
 			// Check for deleted file marker
-			if !containsString(result, "deleted file mode 100644") {
+			if !strings.Contains(result, "deleted file mode 100644") {
 				t.Errorf("missing 'deleted file mode' marker, got:\n%s", result)
 			}
 
 			// Check for /dev/null in new file
-			if !containsString(result, "+++ /dev/null") {
+			if !strings.Contains(result, "+++ /dev/null") {
 				t.Errorf("missing '+++ /dev/null', got:\n%s", result)
 			}
 
 			// Check hunk header format (must be +0,0 for deleted files)
-			if !containsString(result, tc.wantHunk) {
+			if !strings.Contains(result, tc.wantHunk) {
 				t.Errorf("expected hunk header %q, got:\n%s", tc.wantHunk, result)
 			}
 		})
@@ -329,24 +315,24 @@ func TestGenerateUnifiedDiff_ModifiedFile(t *testing.T) {
 			result := generateUnifiedDiff(tc.path, []byte(tc.oldContent), []byte(tc.newContent), false, false)
 
 			// Should NOT have new/deleted file markers
-			if containsString(result, "new file mode") {
+			if strings.Contains(result, "new file mode") {
 				t.Errorf("should not have 'new file mode' for modification, got:\n%s", result)
 			}
-			if containsString(result, "deleted file mode") {
+			if strings.Contains(result, "deleted file mode") {
 				t.Errorf("should not have 'deleted file mode' for modification, got:\n%s", result)
 			}
 
 			// Check for proper file headers (not /dev/null)
-			if !containsString(result, "--- a/"+tc.path) {
+			if !strings.Contains(result, "--- a/"+tc.path) {
 				t.Errorf("missing '--- a/%s', got:\n%s", tc.path, result)
 			}
-			if !containsString(result, "+++ b/"+tc.path) {
+			if !strings.Contains(result, "+++ b/"+tc.path) {
 				t.Errorf("missing '+++ b/%s', got:\n%s", tc.path, result)
 			}
 
 			// Check for minus/plus lines
-			hasMinus := containsString(result, "\n-")
-			hasPlus := containsString(result, "\n+")
+			hasMinus := strings.Contains(result, "\n-")
+			hasPlus := strings.Contains(result, "\n+")
 
 			if tc.wantMinus && !hasMinus {
 				t.Errorf("expected - lines in diff, got:\n%s", result)
@@ -406,7 +392,7 @@ func TestGenerateUnifiedDiff_IdenticalContent(t *testing.T) {
 	result := generateUnifiedDiff("test.txt", content, content, false, false)
 
 	// Identical content should produce no hunks
-	if containsString(result, "@@") {
+	if strings.Contains(result, "@@") {
 		t.Errorf("identical content should not produce hunks, got:\n%s", result)
 	}
 }
@@ -416,7 +402,7 @@ func TestGenerateUnifiedDiff_EmptyToContent(t *testing.T) {
 	result := generateUnifiedDiff("test.txt", []byte{}, []byte("new content\n"), false, false)
 
 	// Should produce a valid diff
-	if !containsString(result, "+new content") {
+	if !strings.Contains(result, "+new content") {
 		t.Errorf("expected '+new content' line, got:\n%s", result)
 	}
 }
@@ -426,7 +412,7 @@ func TestGenerateUnifiedDiff_ContentToEmpty(t *testing.T) {
 	result := generateUnifiedDiff("test.txt", []byte("old content\n"), []byte{}, false, false)
 
 	// Should produce a valid diff
-	if !containsString(result, "-old content") {
+	if !strings.Contains(result, "-old content") {
 		t.Errorf("expected '-old content' line, got:\n%s", result)
 	}
 }
@@ -787,13 +773,13 @@ func TestGenerateUnifiedDiff_LineIntegrity(t *testing.T) {
 			result := generateUnifiedDiff("test.txt", []byte(tc.oldContent), []byte(tc.newContent), false, false)
 
 			for _, want := range tc.wantLines {
-				if !containsString(result, want) {
+				if !strings.Contains(result, want) {
 					t.Errorf("expected diff to contain %q, got:\n%s", want, result)
 				}
 			}
 
 			for _, reject := range tc.rejectLines {
-				if containsString(result, reject) {
+				if strings.Contains(result, reject) {
 					t.Errorf("diff must not contain %q (broken line boundary), got:\n%s", reject, result)
 				}
 			}
@@ -843,7 +829,7 @@ func TestGenerateUnifiedDiff_HunkHeaders(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := generateUnifiedDiff("test.txt", []byte(tc.oldContent), []byte(tc.newContent), false, false)
-			if !containsString(result, tc.wantHeader) {
+			if !strings.Contains(result, tc.wantHeader) {
 				t.Errorf("expected hunk header %q, got:\n%s", tc.wantHeader, result)
 			}
 		})
@@ -877,16 +863,16 @@ func TestGenerateUnifiedDiff_MultipleHunks(t *testing.T) {
 	}
 
 	// Verify both changes appear
-	if !containsString(result, "-old_first\n") {
+	if !strings.Contains(result, "-old_first\n") {
 		t.Errorf("missing -old_first in:\n%s", result)
 	}
-	if !containsString(result, "+new_first\n") {
+	if !strings.Contains(result, "+new_first\n") {
 		t.Errorf("missing +new_first in:\n%s", result)
 	}
-	if !containsString(result, "-old_last\n") {
+	if !strings.Contains(result, "-old_last\n") {
 		t.Errorf("missing -old_last in:\n%s", result)
 	}
-	if !containsString(result, "+new_last\n") {
+	if !strings.Contains(result, "+new_last\n") {
 		t.Errorf("missing +new_last in:\n%s", result)
 	}
 }

--- a/cmd/skills_install.go
+++ b/cmd/skills_install.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"os"
-	"slices"
 	"strings"
 
 	clierrors "github.com/metaplay/cli/internal/errors"
@@ -192,12 +191,6 @@ func flagScopeToScope(flag string) *skillspkg.Scope {
 		return &s
 	}
 	return nil
-}
-
-// containsStr is shared with skills_prompter.go (defined here for now to
-// avoid an extra file). Linear scan; targets are tiny.
-func containsStr(slice []string, s string) bool {
-	return slices.Contains(slice, s)
 }
 
 func reportInstallActions(actions []skillspkg.InstallAction) {

--- a/cmd/skills_prompter.go
+++ b/cmd/skills_prompter.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/metaplay/cli/internal/tui"
@@ -116,7 +117,7 @@ func (p *tuiPrompter) AskTargets(scope skills.Scope, groups []skills.AgentDirGro
 			return g.Path + "/", "— " + strings.Join(g.Tools, ", ")
 		},
 		func(g *skills.AgentDirGroup) bool {
-			return containsStr(defaults, g.Rep.ID)
+			return slices.Contains(defaults, g.Rep.ID)
 		},
 	)
 	if err != nil {

--- a/cmd/test_integration.go
+++ b/cmd/test_integration.go
@@ -260,7 +260,7 @@ func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
 		log.Info().Msg("")
 
 		runFn := t.run
-		if err := o.runTestCase(testRunCtx, project, serverImage, integrationTestsConfig, t.displayName, func(server *testutil.BackgroundGameServer) error {
+		if err := o.runTestCase(testRunCtx, project, serverImage, integrationTestsConfig, func(server *testutil.BackgroundGameServer) error {
 			return runFn(testCtx, server)
 		}); err != nil {
 			return fmt.Errorf("test '%s' failed: %w", t.displayName, err)
@@ -276,7 +276,7 @@ func (o *testIntegrationOpts) Run(cmd *cobra.Command) error {
 }
 
 // runTestCase starts a background game server, runs the provided test function, and then stops the server.
-func (o *testIntegrationOpts) runTestCase(ctx context.Context, project *metaproj.MetaplayProject, serverImage string, integrationTestsConfig *metaproj.IntegrationTestsConfig, displayName string, fn func(*testutil.BackgroundGameServer) error) error {
+func (o *testIntegrationOpts) runTestCase(ctx context.Context, project *metaproj.MetaplayProject, serverImage string, integrationTestsConfig *metaproj.IntegrationTestsConfig, fn func(*testutil.BackgroundGameServer) error) error {
 	// Build server options with any custom configuration
 	serverOpts := testutil.GameServerOptions{
 		Image:         serverImage,
@@ -305,9 +305,7 @@ func (o *testIntegrationOpts) runTestCase(ctx context.Context, project *metaproj
 
 	// Optional: run network debug checks
 	if o.flagDebugNetwork {
-		if err := o.debugNetworkConnectivity(ctx, project, server, serverImage); err != nil {
-			return fmt.Errorf("network connectivity test failed: %w", err)
-		}
+		o.debugNetworkConnectivity(ctx, project, server, serverImage)
 	}
 
 	// Execute the test function
@@ -462,7 +460,7 @@ func (o *testIntegrationOpts) runSystemTests(ctx context.Context, project *metap
 
 // debugNetworkConnectivity runs network tests to help diagnose connectivity issues to the game server container.
 // These tests are run in containers to simulate the same networking as the other test containers will use.
-func (o *testIntegrationOpts) debugNetworkConnectivity(ctx context.Context, project *metaproj.MetaplayProject, server *testutil.BackgroundGameServer, serverImage string) error {
+func (o *testIntegrationOpts) debugNetworkConnectivity(ctx context.Context, project *metaproj.MetaplayProject, server *testutil.BackgroundGameServer, serverImage string) {
 	// Test 1: Check if we can resolve localhost from within the botclient container network
 	log.Info().Msg("Test 1: DNS resolution test")
 	dnsTestOpts := testutil.RunOnceContainerOptions{
@@ -532,8 +530,6 @@ func (o *testIntegrationOpts) debugNetworkConnectivity(ctx context.Context, proj
 	} else {
 		log.Info().Msg("Process test completed - check logs for gameserver process")
 	}
-
-	return nil
 }
 
 // buildDockerImages builds the Docker images used by integration tests. This includes

--- a/cmd/update_sdk.go
+++ b/cmd/update_sdk.go
@@ -303,7 +303,7 @@ func (o *updateSdkOpts) Run(cmd *cobra.Command) error {
 	}
 
 	// Validate the target SDK version is supported
-	if _, err := parseAndValidateSdkVersion(targetVersion.Version); err != nil {
+	if err := parseAndValidateSdkVersion(targetVersion.Version); err != nil {
 		return err
 	}
 
@@ -321,7 +321,7 @@ func (o *updateSdkOpts) Run(cmd *cobra.Command) error {
 	// Download and extract new SDK
 	log.Info().Msgf("  Downloading and extracting SDK %s...", styles.RenderTechnical(targetVersion.Version))
 	parentDir := filepath.Dir(sdkRootDirAbs)
-	if _, err := downloadAndExtractSdk(tokenSet, parentDir, targetVersion); err != nil {
+	if err := downloadAndExtractSdk(tokenSet, parentDir, targetVersion); err != nil {
 		return fmt.Errorf("failed to download and extract SDK: %w", err)
 	}
 

--- a/internal/errors/cli_error.go
+++ b/internal/errors/cli_error.go
@@ -122,15 +122,13 @@ func WrapUsageError(cause error, message string) *CLIError {
 
 // IsUsageError checks if an error is a usage error (should show usage help).
 func IsUsageError(err error) bool {
-	if cliErr, ok := errors.AsType[*CLIError](err); ok {
-		return cliErr.IsUsageError()
-	}
-	return false
+	cliErr, ok := AsCLIError(err)
+	return ok && cliErr.IsUsageError()
 }
 
 // GetExitCode returns the appropriate exit code for an error.
 func GetExitCode(err error) int {
-	if cliErr, ok := errors.AsType[*CLIError](err); ok {
+	if cliErr, ok := AsCLIError(err); ok {
 		return int(cliErr.Code)
 	}
 	return int(ExitRuntime) // Default to runtime error

--- a/pkg/envapi/wait_server_ready_test.go
+++ b/pkg/envapi/wait_server_ready_test.go
@@ -29,11 +29,11 @@ func TestBuildHealthCheckPacket(t *testing.T) {
 
 func TestParseProtocolHeader(t *testing.T) {
 	tests := []struct {
-		name      string
-		data      []byte
-		wantErr   bool
-		version   byte
-		status    byte
+		name    string
+		data    []byte
+		wantErr bool
+		version byte
+		status  byte
 	}{
 		{
 			name:    "valid header",
@@ -149,4 +149,3 @@ func TestValidateProtocolHeader(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/portalapi/portalapi.go
+++ b/pkg/portalapi/portalapi.go
@@ -304,10 +304,7 @@ func (c *Client) FindSdkVersionByVersionOrName(versionOrName string) (*SdkVersio
 	// If input looks like a major version only (digits with no dots), find the latest for that major.
 	// Check this before name matching, so "34" finds latest 34.x instead of matching a name.
 	if IsMajorVersionOnly(versionOrName) {
-		result, err := findLatestForMajorVersion(versions, versionOrName)
-		if err != nil {
-			return nil, err
-		}
+		result := findLatestForMajorVersion(versions, versionOrName)
 		if result != nil {
 			log.Debug().Msgf("Resolved major version %s to %s", versionOrName, result.Version)
 			return result, nil
@@ -359,7 +356,7 @@ func IsMajorVersionOnly(version string) bool {
 }
 
 // findLatestForMajorVersion finds the latest SDK version matching the given major version.
-func findLatestForMajorVersion(versions []SdkVersionInfo, majorVersion string) (*SdkVersionInfo, error) {
+func findLatestForMajorVersion(versions []SdkVersionInfo, majorVersion string) *SdkVersionInfo {
 	prefix := majorVersion + "."
 	var best *SdkVersionInfo
 	var bestMinor, bestPatch = -1, -1
@@ -383,7 +380,7 @@ func findLatestForMajorVersion(versions []SdkVersionInfo, majorVersion string) (
 		}
 	}
 
-	return best, nil
+	return best
 }
 
 // parseMinorPatch parses "3" or "3.1" into minor and patch numbers.

--- a/pkg/skills/run_install_test.go
+++ b/pkg/skills/run_install_test.go
@@ -19,8 +19,8 @@ type fakePrompter struct {
 	scopeErr       error
 	scopeCallCount int
 
-	chosenIDs       []string
-	targetsErr      error
+	chosenIDs        []string
+	targetsErr       error
 	targetsCallCount int
 
 	// Captured arguments for assertions.

--- a/pkg/skills/run_remove.go
+++ b/pkg/skills/run_remove.go
@@ -4,7 +4,6 @@
 
 package skills
 
-
 // RemoveRequest is the high-level input to RunRemove. It mirrors
 // InstallRequest's shape so callers that wire up both flows can reuse
 // scope/target resolution logic.
@@ -97,4 +96,3 @@ func resolveRemoveScope(req RemoveRequest) (Scope, error) {
 	}
 	return ScopeProject, nil
 }
-


### PR DESCRIPTION
Follow-up to #165. Four self-contained commits, net **-92 lines** across 20 files.

| Commit | What |
|---|---|
| Remove hand-rolled stdlib helpers | 4 helpers deleted, 25 call sites |
| Drop dead parameters and unreachable error paths | 8 of 13 `unparam` findings |
| Enforce gofmt in CI and fix the drift | new `.golangci.yml`, 4 files reformatted |
| Collapse duplicated SQL import path; simplify formatDuration | ~48 duplicated lines removed |

## Notes for review

**Why the gofmt drift survived.** Four files had been unformatted on `main` for a while because CI runs `golangci-lint-action` directly, not `make lint`, and neither ran gofmt. Adding a `gofmt -l` step to the Makefile would have fixed the local loop and left CI blind, so this adds a `.golangci.yml` enabling golangci-lint's `gofmt` formatter, which bare `golangci-lint run` picks up in both places. Verified that `golangci-lint linters` reports a byte-identical enabled set with and without the config — the default linter selection is unchanged.

**The config also lifts the issue caps.** golangci-lint defaults to `max-issues-per-linter: 50` and `max-same-issues: 3`, which truncate silently: the first run of the new gofmt check reported 3 of the 4 unformatted files and looked complete. Both are now unlimited.

**Every removed error return was provably unreachable**, not a swallowed failure — I checked each body rather than trusting the linter. `getAllShardTables` deliberately logs a per-shard failure and records an empty shard; `collectAndRetrieveHeapDump` only registers TaskRunner tasks, so real failures surface from the caller's `runner.Run()`; `debugNetworkConnectivity` warns per probe and continues; `getHelmReleaseInfo` builds a struct from fields already in hand; `findLatestForMajorVersion` just scans a slice, where "no match" is a nil result.

**Five `unparam` findings were left alone deliberately.** `fetchGameServerShardSets`' `newGameServer` and `pollMetricsOnce`' `ctx` are placeholders for the `\todo` directly above each (the latter's comment spells out the `http.NewRequestWithContext(ctx, ...)` it is reserved for). `getImageInfo`'s `ctx` is unused only because `GetDetails`/`GetDockerCredentials` do not accept one yet — dropping it would be the wrong direction; threading context into those is a separate change. `validateStep`'s `numShards` and `managedWrapper`'s `version` are meaningful parameters that merely happen to receive one value today.

**Three user-visible string changes** fall out of merging the two import functions, all in `database_import_archive.go`:

- error: `"database import failed"` → `"shard import failed"` (matches what actually failed)
- debug log: `"Executing mariadb import command"` → `"Executing shard import command"`
- debug logs: `"Schema/Shard imported successfully"` → lowercase initial

The `failed to open <kind> file %s` errors, the `schema_file`/`shard_file` log field keys, and the `failed to apply schema to shard %d` / `failed to import shard %d data` wrappers at the call sites are all unchanged. No test asserts on any of these strings.

**`containsString` → `strings.Contains` has a semantic difference** that needed checking: the old helper returned `false` for an empty substring where `strings.Contains` returns `true`. That only matters for the `rejectLines` assertions, which invert the result — every entry there is a non-empty literal. The non-inverted assertions were safe by construction, since an empty string in any of them would already have been failing on `main`.

**`formatDuration` was rewritten without test coverage**, so rather than rely on reasoning I diffed old against new across every input in `[-100000, 400000]`, including negatives: 0 mismatches.

## Verification

- `make lint` (now including gofmt) 0 issues
- `go test ./...` fully passing, `go vet ./...` clean
- `go mod tidy` a no-op