### PR TITLE
Wrap errors with %w so the chain survives

### DIFF
--- a/cmd/build_image.go
+++ b/cmd/build_image.go
@@ -325,9 +325,9 @@ func checkCommand(ctx context.Context, command string, args ...string) error {
 		}
 		trimmed := strings.TrimSpace(stderr.String())
 		if trimmed != "" {
-			return fmt.Errorf("%v: %s", err, truncateForLog(trimmed, 500))
+			return fmt.Errorf("%w: %s", err, truncateForLog(trimmed, 500))
 		}
-		return fmt.Errorf("command failed: %v", err)
+		return fmt.Errorf("command failed: %w", err)
 	}
 	return nil
 }

--- a/cmd/dashboard_helper.go
+++ b/cmd/dashboard_helper.go
@@ -47,7 +47,7 @@ func checkNodeVersion(ctx context.Context, recommendedVersion *version.Version) 
 	// Parse installed Node version
 	installedVersion, err := version.NewVersion(installedVersionStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse Node.js version from '%s': %s", installedVersionStr, err)
+		return fmt.Errorf("failed to parse Node.js version from '%s': %w", installedVersionStr, err)
 	}
 
 	// Fail if version older than recommended.
@@ -96,7 +96,7 @@ func checkPnpmVersion(ctx context.Context, recommendedVersion *version.Version) 
 	installedVersionStr := strings.TrimSpace(out.String())
 	installedVersion, err := version.NewVersion(installedVersionStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse pnpm version from '%s': %v", installedVersionStr, err)
+		return fmt.Errorf("failed to parse pnpm version from '%s': %w", installedVersionStr, err)
 	}
 
 	// Fail if installed version is older than required.

--- a/cmd/database_export_archive.go
+++ b/cmd/database_export_archive.go
@@ -121,13 +121,13 @@ func (o *databaseExportArchiveOpts) Run(cmd *cobra.Command) error {
 	// Configure Helm to check for active deployments
 	actionConfig, err := helmutil.NewActionConfig(kubeCli.KubeConfig, envConfig.GetKubernetesNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm config: %v", err)
+		return fmt.Errorf("failed to initialize Helm config: %w", err)
 	}
 
 	// Check for any active game server Helm deployments - refuse to export if found
 	helmReleases, err := helmutil.HelmListReleases(actionConfig, "metaplay-gameserver")
 	if err != nil {
-		return fmt.Errorf("failed to check for existing Helm releases: %v", err)
+		return fmt.Errorf("failed to check for existing Helm releases: %w", err)
 	}
 	hasGameServer := len(helmReleases) > 0
 
@@ -224,7 +224,7 @@ func (o *databaseExportArchiveOpts) exportDatabaseContents(ctx context.Context, 
 	log.Debug().Str("zip_file", o.argOutputFile).Msg("Creating output zip file")
 	zipFile, err := os.Create(o.argOutputFile)
 	if err != nil {
-		return fmt.Errorf("failed to create zip file: %v", err)
+		return fmt.Errorf("failed to create zip file: %w", err)
 	}
 	defer func() { _ = zipFile.Close() }()
 
@@ -243,14 +243,14 @@ func (o *databaseExportArchiveOpts) exportDatabaseContents(ctx context.Context, 
 	log.Debug().Msg("Writing metadata to zip file")
 	err = o.writeMetadataToZip(zipWriter, shards, masterVersion)
 	if err != nil {
-		return fmt.Errorf("failed to write metadata: %v", err)
+		return fmt.Errorf("failed to write metadata: %w", err)
 	}
 
 	// Extract schema from shard #0 first
 	log.Debug().Msg("Extracting database schema from shard #0")
 	schemaContent, err := o.extractDatabaseSchema(ctx, kubeCli, podName, debugContainerName, shards[0])
 	if err != nil {
-		return fmt.Errorf("failed to extract schema: %v", err)
+		return fmt.Errorf("failed to extract schema: %w", err)
 	}
 
 	// Apply schema fixups
@@ -259,7 +259,7 @@ func (o *databaseExportArchiveOpts) exportDatabaseContents(ctx context.Context, 
 	// Write schema to zip file
 	err = o.writeSchemaToZip(zipWriter, schemaContent)
 	if err != nil {
-		return fmt.Errorf("failed to write schema to zip: %v", err)
+		return fmt.Errorf("failed to write schema to zip: %w", err)
 	}
 
 	// Export data from each shard
@@ -267,7 +267,7 @@ func (o *databaseExportArchiveOpts) exportDatabaseContents(ctx context.Context, 
 		log.Debug().Int("shard_index", shard.ShardIndex).Str("database_name", shard.DatabaseName).Msg("Starting shard data export")
 		shardFileName, err := o.exportDatabaseShardData(ctx, zipWriter, kubeCli, podName, debugContainerName, shard)
 		if err != nil {
-			return fmt.Errorf("failed to export shard %d data: %v", shard.ShardIndex, err)
+			return fmt.Errorf("failed to export shard %d data: %w", shard.ShardIndex, err)
 		}
 		log.Debug().Int("shard_index", shard.ShardIndex).Str("shard_file", shardFileName).Msg("Shard data export completed")
 	}
@@ -298,7 +298,7 @@ func (o *databaseExportArchiveOpts) writeMetadataToZip(zipWriter *zip.Writer, sh
 	// Create metadata JSON in memory
 	metadataBytes, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal metadata: %v", err)
+		return fmt.Errorf("failed to marshal metadata: %w", err)
 	}
 
 	// Write metadata file to zip
@@ -313,10 +313,10 @@ func (o *databaseExportArchiveOpts) writeMetadataToZip(zipWriter *zip.Writer, sh
 	// Write metadata file to zip
 	metadataWriter, err := zipWriter.CreateHeader(metadataHeader)
 	if err != nil {
-		return fmt.Errorf("failed to create metadata writer: %v", err)
+		return fmt.Errorf("failed to create metadata writer: %w", err)
 	}
 	if _, err := metadataWriter.Write(metadataBytes); err != nil {
-		return fmt.Errorf("failed to write metadata content: %v", err)
+		return fmt.Errorf("failed to write metadata content: %w", err)
 	}
 
 	return nil
@@ -361,7 +361,7 @@ func (o *databaseExportArchiveOpts) extractDatabaseSchema(ctx context.Context, k
 	err := execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false)
 	if err != nil {
 		log.Error().Err(err).Msg("Schema extraction failed - aborting export")
-		return "", fmt.Errorf("CRITICAL: schema extraction failed: %v", err)
+		return "", fmt.Errorf("CRITICAL: schema extraction failed: %w", err)
 	}
 
 	schemaContent := schemaBuffer.String()
@@ -420,13 +420,13 @@ func (o *databaseExportArchiveOpts) writeSchemaToZip(zipWriter *zip.Writer, sche
 	// Create zip writer for schema file
 	schemaWriter, err := zipWriter.CreateHeader(schemaHeader)
 	if err != nil {
-		return fmt.Errorf("failed to create schema writer: %v", err)
+		return fmt.Errorf("failed to create schema writer: %w", err)
 	}
 
 	// Write schema content to zip
 	_, err = schemaWriter.Write([]byte(schemaContent))
 	if err != nil {
-		return fmt.Errorf("failed to write schema content: %v", err)
+		return fmt.Errorf("failed to write schema content: %w", err)
 	}
 
 	log.Debug().Msg("Schema written to schema.sql in zip archive")
@@ -456,7 +456,7 @@ func (o *databaseExportArchiveOpts) exportDatabaseShardData(ctx context.Context,
 	// Create zip writer for this file - stream directly without buffering
 	shardFileWriter, err := zipWriter.CreateHeader(shardHeader)
 	if err != nil {
-		return "", fmt.Errorf("failed to create zip writer: %v", err)
+		return "", fmt.Errorf("failed to create zip writer: %w", err)
 	}
 
 	// Execute mariadb-dump command and stream output directly to zip
@@ -484,7 +484,7 @@ func (o *databaseExportArchiveOpts) exportDatabaseShardData(ctx context.Context,
 
 	err = execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false)
 	if err != nil {
-		return "", fmt.Errorf("shard %d data export failed: %v", shard.ShardIndex, err)
+		return "", fmt.Errorf("shard %d data export failed: %w", shard.ShardIndex, err)
 	}
 	log.Debug().Str("file", shardFileName).Msg("Shard data streamed directly to zip archive")
 

--- a/cmd/database_import_archive.go
+++ b/cmd/database_import_archive.go
@@ -141,7 +141,7 @@ func (o *databaseImportArchiveOpts) Run(cmd *cobra.Command) error {
 	// cluster round-trips.
 	zipReader, metadata, schemaFile, shardFiles, err := o.openAndValidateZipFile()
 	if err != nil {
-		return fmt.Errorf("failed to validate zip file: %v", err)
+		return fmt.Errorf("failed to validate zip file: %w", err)
 	}
 	defer func() { _ = zipReader.Close() }()
 	log.Debug().Str("source_env", metadata.Environment).Str("database", metadata.DatabaseName).Int("shards", metadata.NumShards).Msg("Import metadata validated")
@@ -165,13 +165,13 @@ func (o *databaseImportArchiveOpts) Run(cmd *cobra.Command) error {
 	// Configure Helm to check for active deployments
 	actionConfig, err := helmutil.NewActionConfig(kubeCli.KubeConfig, envConfig.GetKubernetesNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm config: %v", err)
+		return fmt.Errorf("failed to initialize Helm config: %w", err)
 	}
 
 	// Check for a game server is deployed - dangerous to import if there is a deployment
 	helmReleases, err := helmutil.HelmListReleases(actionConfig, "metaplay-gameserver")
 	if err != nil {
-		return fmt.Errorf("failed to check for existing Helm releases: %v", err)
+		return fmt.Errorf("failed to check for existing Helm releases: %w", err)
 	}
 	hasGameServer := len(helmReleases) > 0
 
@@ -297,7 +297,7 @@ func (o *databaseImportArchiveOpts) importDatabaseContents(ctx context.Context, 
 		log.Debug().Int("shard_index", targetShard.ShardIndex).Str("database_name", targetShard.DatabaseName).Msg("Apply schema to shard")
 		err := o.importSQLFromZip(ctx, "schema", schemaFile, kubeCli, podName, debugContainerName, targetShard)
 		if err != nil {
-			return fmt.Errorf("failed to apply schema to shard %d: %v", targetShard.ShardIndex, err)
+			return fmt.Errorf("failed to apply schema to shard %d: %w", targetShard.ShardIndex, err)
 		}
 		log.Debug().Int("shard_index", targetShard.ShardIndex).Msg("Schema applied to shard")
 	}
@@ -310,7 +310,7 @@ func (o *databaseImportArchiveOpts) importDatabaseContents(ctx context.Context, 
 
 		err := o.importSQLFromZip(ctx, "shard", shardFile, kubeCli, podName, debugContainerName, targetShard)
 		if err != nil {
-			return fmt.Errorf("failed to import shard %d data: %v", targetShard.ShardIndex, err)
+			return fmt.Errorf("failed to import shard %d data: %w", targetShard.ShardIndex, err)
 		}
 		log.Debug().Int("shard_index", targetShard.ShardIndex).Msg("Shard data import completed")
 	}
@@ -342,7 +342,7 @@ func (o *databaseImportArchiveOpts) openAndValidateZipFile() (*zip.ReadCloser, *
 	// Open zip file
 	zipReader, err := zip.OpenReader(o.argInputFile)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to open zip file: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to open zip file: %w", err)
 	}
 
 	// Find and read metadata file, schema file, and shard files
@@ -377,7 +377,7 @@ func (o *databaseImportArchiveOpts) openAndValidateZipFile() (*zip.ReadCloser, *
 	metadataReader, err := metadataFile.Open()
 	if err != nil {
 		_ = zipReader.Close()
-		return nil, nil, nil, nil, fmt.Errorf("failed to open metadata file: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to open metadata file: %w", err)
 	}
 	defer func() { _ = metadataReader.Close() }()
 
@@ -385,7 +385,7 @@ func (o *databaseImportArchiveOpts) openAndValidateZipFile() (*zip.ReadCloser, *
 	metadataBytes, err := io.ReadAll(metadataReader)
 	if err != nil {
 		_ = zipReader.Close()
-		return nil, nil, nil, nil, fmt.Errorf("failed to read metadata: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to read metadata: %w", err)
 	}
 
 	// Parse archive metadata.
@@ -393,7 +393,7 @@ func (o *databaseImportArchiveOpts) openAndValidateZipFile() (*zip.ReadCloser, *
 	err = json.Unmarshal(metadataBytes, &metadata)
 	if err != nil {
 		_ = zipReader.Close()
-		return nil, nil, nil, nil, fmt.Errorf("failed to parse metadata: %v", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to parse metadata: %w", err)
 	}
 
 	// Check version compatibility
@@ -412,7 +412,7 @@ func (o *databaseImportArchiveOpts) openAndValidateZipFile() (*zip.ReadCloser, *
 func (o *databaseImportArchiveOpts) importSQLFromZip(ctx context.Context, kind string, file *zip.File, kubeCli *envapi.KubeClient, podName, debugContainerName string, targetShard kubeutil.DatabaseShardConfig) error {
 	reader, err := file.Open()
 	if err != nil {
-		return fmt.Errorf("failed to open %s file %s: %v", kind, file.Name, err)
+		return fmt.Errorf("failed to open %s file %s: %w", kind, file.Name, err)
 	}
 	defer func() { _ = reader.Close() }()
 
@@ -447,7 +447,7 @@ func (o *databaseImportArchiveOpts) importSQLFromZip(ctx context.Context, kind s
 	}
 
 	if err := execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false); err != nil {
-		return fmt.Errorf("%s import failed: %v", kind, err)
+		return fmt.Errorf("%s import failed: %w", kind, err)
 	}
 	log.Debug().Str(kind+"_file", file.Name).Msgf("%s imported successfully", kind)
 

--- a/cmd/database_reset.go
+++ b/cmd/database_reset.go
@@ -120,14 +120,14 @@ func (o *databaseResetOpts) Run(cmd *cobra.Command) error {
 	// Get kubeconfig to access the environment for Helm operations
 	kubeconfigPayload, err := targetEnv.GetKubeConfigWithEmbeddedCredentials()
 	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig: %v", err)
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 	log.Debug().Msg("Resolved kubeconfig to access environment")
 
 	// Configure Helm to check for active deployments
 	actionConfig, err := helmutil.NewActionConfig(kubeconfigPayload, envConfig.GetKubernetesNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm config: %v", err)
+		return fmt.Errorf("failed to initialize Helm config: %w", err)
 	}
 
 	// Check for any active game server Helm deployments - refuse to reset if found
@@ -263,7 +263,7 @@ func (o *databaseResetOpts) resetDatabaseContents(ctx context.Context, kubeCli *
 	log.Info().Msg("Phase 0: Mark reset in progress...")
 	err := o.markResetInProgress(ctx, kubeCli, podName, debugContainerName, shards[0])
 	if err != nil {
-		return fmt.Errorf("failed to mark reset in progress: %v", err)
+		return fmt.Errorf("failed to mark reset in progress: %w", err)
 	}
 
 	// Phase 1: Drop all tables except MetaInfo in all shards
@@ -273,7 +273,7 @@ func (o *databaseResetOpts) resetDatabaseContents(ctx context.Context, kubeCli *
 		tables := allShardTables[shard.ShardIndex]
 		err := o.resetShardPhase1(ctx, kubeCli, podName, debugContainerName, shard, tables)
 		if err != nil {
-			return fmt.Errorf("failed to reset shard %d phase 1: %v", shard.ShardIndex, err)
+			return fmt.Errorf("failed to reset shard %d phase 1: %w", shard.ShardIndex, err)
 		}
 		log.Debug().Int("shard_index", shard.ShardIndex).Msg("Shard reset phase 1 completed")
 	}
@@ -286,7 +286,7 @@ func (o *databaseResetOpts) resetDatabaseContents(ctx context.Context, kubeCli *
 		log.Debug().Int("shard_index", shard.ShardIndex).Str("database_name", shard.DatabaseName).Msg("Starting shard reset phase 2")
 		err := o.resetShardPhase2(ctx, kubeCli, podName, debugContainerName, shard)
 		if err != nil {
-			return fmt.Errorf("failed to reset shard %d phase 2: %v", shard.ShardIndex, err)
+			return fmt.Errorf("failed to reset shard %d phase 2: %w", shard.ShardIndex, err)
 		}
 		log.Debug().Int("shard_index", shard.ShardIndex).Msg("Shard reset phase 2 completed")
 	}
@@ -310,7 +310,7 @@ func (o *databaseResetOpts) markResetInProgress(ctx context.Context, kubeCli *en
 	err := o.executeSQLCommand(ctx, kubeCli, podName, debugContainerName, mainShard, sqlCmd)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to mark reset in progress (table may not exist yet)")
-		return fmt.Errorf("failed to mark reset in progress: %v", err)
+		return fmt.Errorf("failed to mark reset in progress: %w", err)
 	}
 	log.Debug().Msg("Marked reset in progress")
 
@@ -334,7 +334,7 @@ func (o *databaseResetOpts) resetShardPhase1(ctx context.Context, kubeCli *envap
 		sqlCmd := fmt.Sprintf("DROP TABLE IF EXISTS `%s`;", table)
 		err := o.executeSQLCommand(ctx, kubeCli, podName, debugContainerName, shard, sqlCmd)
 		if err != nil {
-			return fmt.Errorf("failed to drop table %s: %v", table, err)
+			return fmt.Errorf("failed to drop table %s: %w", table, err)
 		}
 		log.Debug().Int("shard_index", shard.ShardIndex).Str("table", table).Msg("Dropped table")
 	}
@@ -349,7 +349,7 @@ func (o *databaseResetOpts) resetShardPhase2(ctx context.Context, kubeCli *envap
 	sqlCmd := "DROP TABLE IF EXISTS `MetaInfo`;"
 	err := o.executeSQLCommand(ctx, kubeCli, podName, debugContainerName, shard, sqlCmd)
 	if err != nil {
-		return fmt.Errorf("failed to drop MetaInfo table: %v", err)
+		return fmt.Errorf("failed to drop MetaInfo table: %w", err)
 	}
 
 	log.Debug().Int("shard_index", shard.ShardIndex).Msg("Dropped MetaInfo table")
@@ -363,7 +363,7 @@ func (o *databaseResetOpts) getTableNames(ctx context.Context, kubeCli *envapi.K
 	// Execute the command and capture output
 	output, err := o.executeSQLCommandWithOutput(ctx, kubeCli, podName, debugContainerName, shard, sqlCmd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute SHOW TABLES: %v", err)
+		return nil, fmt.Errorf("failed to execute SHOW TABLES: %w", err)
 	}
 
 	// Parse the output to extract table names
@@ -420,7 +420,7 @@ func (o *databaseResetOpts) executeSQLCommand(ctx context.Context, kubeCli *enva
 
 	err := execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false)
 	if err != nil {
-		return fmt.Errorf("SQL command execution failed: %v", err)
+		return fmt.Errorf("SQL command execution failed: %w", err)
 	}
 
 	return nil
@@ -464,7 +464,7 @@ func (o *databaseResetOpts) executeSQLCommandWithOutput(ctx context.Context, kub
 
 	err := execRemoteKubernetesCommand(ctx, kubeCli.RestConfig, req.URL(), ioStreams, false, false)
 	if err != nil {
-		return "", fmt.Errorf("SQL command execution failed: %v", err)
+		return "", fmt.Errorf("SQL command execution failed: %w", err)
 	}
 
 	return outputBuffer.String(), nil

--- a/cmd/debug_admin_request.go
+++ b/cmd/debug_admin_request.go
@@ -177,7 +177,7 @@ func (o *debugAdminRequestOpts) Run(cmd *cobra.Command) error {
 		// Read content from file
 		fileContent, err := os.ReadFile(o.flagFile)
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %v", o.flagFile, err)
+			return fmt.Errorf("failed to read file %s: %w", o.flagFile, err)
 		}
 		requestBody = fileContent
 
@@ -221,14 +221,14 @@ func (o *debugAdminRequestOpts) Run(cmd *cobra.Command) error {
 
 		response, err := request.Execute(o.argMethod, o.argPath)
 		if err != nil {
-			return fmt.Errorf("request failed: %v", err)
+			return fmt.Errorf("request failed: %w", err)
 		}
 		if response.StatusCode() < http.StatusOK || response.StatusCode() >= http.StatusMultipleChoices {
 			return fmt.Errorf("request failed with status %d: %s", response.StatusCode(), response.String())
 		}
 
 		if err := os.WriteFile(o.flagOutput, response.Body(), 0644); err != nil {
-			return fmt.Errorf("failed to write output file: %v", err)
+			return fmt.Errorf("failed to write output file: %w", err)
 		}
 
 		log.Info().Msgf("Saved response to %s (%d bytes)", o.flagOutput, len(response.Body()))
@@ -253,7 +253,7 @@ func (o *debugAdminRequestOpts) Run(cmd *cobra.Command) error {
 	}
 
 	if requestErr != nil {
-		return fmt.Errorf("request failed: %v", requestErr)
+		return fmt.Errorf("request failed: %w", requestErr)
 	}
 
 	// If no response body was returned, print something to acknowledge the result

--- a/cmd/debug_collect_cpu_profile.go
+++ b/cmd/debug_collect_cpu_profile.go
@@ -256,7 +256,7 @@ func (o *debugCollectCPUProfileOpts) collectAndRetrieveCPUProfile(ctx context.Co
 		// Execute the command in the debug container
 		_, _, err := kubeutil.ExecInDebugContainer(ctx, kubeCli, podName, debugContainerName, collectCmd)
 		if err != nil {
-			return fmt.Errorf("failed to collect CPU profile: %v", err)
+			return fmt.Errorf("failed to collect CPU profile: %w", err)
 		}
 
 		return nil
@@ -283,7 +283,7 @@ func (o *debugCollectCPUProfileOpts) collectAndRetrieveCPUProfile(ctx context.Co
 		}
 
 		if copyErr != nil {
-			return fmt.Errorf("failed to copy CPU profile: %v", copyErr)
+			return fmt.Errorf("failed to copy CPU profile: %w", copyErr)
 		}
 		return nil
 	})

--- a/cmd/debug_collect_heap_dump.go
+++ b/cmd/debug_collect_heap_dump.go
@@ -218,7 +218,7 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 			"curl localhost:8585/setOverride/healthz?mode=Success",
 		)
 		if err != nil {
-			return fmt.Errorf("failed to set healthz probe mode: %v", err)
+			return fmt.Errorf("failed to set healthz probe mode: %w", err)
 		}
 		return nil
 	})
@@ -243,7 +243,7 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 		_, _, err := kubeutil.ExecInDebugContainer(ctx, kubeCli, podName, debugContainerName, collectCmd)
 		dumpDuration = time.Since(startTime)
 		if err != nil {
-			return fmt.Errorf("failed to collect heap dump: %v", err)
+			return fmt.Errorf("failed to collect heap dump: %w", err)
 		}
 
 		// Calculate and log dump rate
@@ -259,7 +259,7 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 			"curl localhost:8585/setOverride/healthz?mode=Passthrough",
 		)
 		if err != nil {
-			return fmt.Errorf("failed to reset healthz probe mode: %v", err)
+			return fmt.Errorf("failed to reset healthz probe mode: %w", err)
 		}
 		return nil
 	})
@@ -287,7 +287,7 @@ func (o *debugCollectHeapDumpOpts) collectAndRetrieveHeapDump(ctx context.Contex
 		}
 
 		if copyErr != nil {
-			return fmt.Errorf("failed to copy heap dump: %v", copyErr)
+			return fmt.Errorf("failed to copy heap dump: %w", copyErr)
 		}
 		return nil
 	})

--- a/cmd/debug_database.go
+++ b/cmd/debug_database.go
@@ -293,7 +293,7 @@ func (o *debugDatabaseOpts) connectToDatabaseShard(ctx context.Context, kubeCli 
 			// Stream query file directly to mariadb stdin
 			queryFile, err := os.Open(o.flagQueryFile)
 			if err != nil {
-				return fmt.Errorf("failed to open query file '%s': %v", o.flagQueryFile, err)
+				return fmt.Errorf("failed to open query file '%s': %w", o.flagQueryFile, err)
 			}
 			defer func() { _ = queryFile.Close() }()
 			stdin = queryFile
@@ -304,7 +304,7 @@ func (o *debugDatabaseOpts) connectToDatabaseShard(ctx context.Context, kubeCli 
 		if o.flagOutput != "" {
 			file, err := os.Create(o.flagOutput)
 			if err != nil {
-				return fmt.Errorf("failed to open output file '%s': %v", o.flagOutput, err)
+				return fmt.Errorf("failed to open output file '%s': %w", o.flagOutput, err)
 			}
 			defer func() { _ = file.Close() }()
 			stdout = file

--- a/cmd/debug_server_status.go
+++ b/cmd/debug_server_status.go
@@ -89,7 +89,7 @@ func (o *debugCheckServerStatus) Run(cmd *cobra.Command) error {
 	// Get docker credentials.
 	dockerCredentials, err := targetEnv.GetDockerCredentials(envDetails)
 	if err != nil {
-		return fmt.Errorf("failed to get docker credentials: %v", err)
+		return fmt.Errorf("failed to get docker credentials: %w", err)
 	}
 	log.Debug().Msgf("Got docker credentials: username=%s", dockerCredentials.Username)
 
@@ -102,7 +102,7 @@ func (o *debugCheckServerStatus) Run(cmd *cobra.Command) error {
 	// Configure Helm.
 	actionConfig, err := helmutil.NewActionConfig(kubeCli.KubeConfig, envConfig.GetKubernetesNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm config: %v", err)
+		return fmt.Errorf("failed to initialize Helm config: %w", err)
 	}
 
 	// Determine if there's an existing release deployed.

--- a/cmd/deploy_botclient.go
+++ b/cmd/deploy_botclient.go
@@ -126,7 +126,7 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 	if o.flagHelmChartLocalPath != "" {
 		err = helmutil.ValidateLocalHelmChart(o.flagHelmChartLocalPath)
 		if err != nil {
-			return fmt.Errorf("invalid --helm-chart-path: %v", err)
+			return fmt.Errorf("invalid --helm-chart-path: %w", err)
 		}
 	} else {
 		// Resolve Helm chart version to use, either from config file or command line override
@@ -141,7 +141,7 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 			// Parse Helm chart semver range.
 			chartVersionConstraints, err = version.NewConstraint(helmChartVersion)
 			if err != nil {
-				return fmt.Errorf("invalid Helm chart version: %v", err)
+				return fmt.Errorf("invalid Helm chart version: %w", err)
 			}
 			log.Debug().Msgf("Accepted Helm chart semver constraints: %v", chartVersionConstraints)
 		}
@@ -215,7 +215,7 @@ func (o *deployBotClientOpts) Run(cmd *cobra.Command) error {
 	// Configure Helm.
 	actionConfig, err := helmutil.NewActionConfig(kubeconfigPayload, envConfig.GetKubernetesNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm config: %v", err)
+		return fmt.Errorf("failed to initialize Helm config: %w", err)
 	}
 
 	// Determine if there's an existing release deployed.

--- a/cmd/deploy_server.go
+++ b/cmd/deploy_server.go
@@ -142,7 +142,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 	if o.flagHelmChartLocalPath != "" {
 		err = helmutil.ValidateLocalHelmChart(o.flagHelmChartLocalPath)
 		if err != nil {
-			return fmt.Errorf("invalid --helm-chart-path: %v", err)
+			return fmt.Errorf("invalid --helm-chart-path: %w", err)
 		}
 	} else {
 		// Resolve Helm chart version to use, either from config file or command line override
@@ -157,7 +157,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 			// Parse Helm chart semver range.
 			chartVersionConstraints, err = version.NewConstraint(helmChartVersion)
 			if err != nil {
-				return fmt.Errorf("invalid Helm chart version: %v", err)
+				return fmt.Errorf("invalid Helm chart version: %w", err)
 			}
 			log.Debug().Msgf("Accepted Helm chart semver constraints: %v", chartVersionConstraints)
 		}
@@ -172,7 +172,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 	// Get docker credentials.
 	dockerCredentials, err := targetEnv.GetDockerCredentials(envDetails)
 	if err != nil {
-		return fmt.Errorf("failed to get docker credentials: %v", err)
+		return fmt.Errorf("failed to get docker credentials: %w", err)
 	}
 	log.Debug().Msgf("Got docker credentials: username=%s", dockerCredentials.Username)
 
@@ -260,7 +260,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 	// Configure Helm.
 	actionConfig, err := helmutil.NewActionConfig(kubeCli.KubeConfig, envConfig.GetKubernetesNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm config: %v", err)
+		return fmt.Errorf("failed to initialize Helm config: %w", err)
 	}
 
 	// Determine if there's an existing release deployed.
@@ -278,7 +278,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 		// Parse the new chart version.
 		newVersion, err := semver.NewVersion(useHelmChartVersion)
 		if err != nil {
-			return fmt.Errorf("failed to parse Helm chart version '%s': %v", useHelmChartVersion, err)
+			return fmt.Errorf("failed to parse Helm chart version '%s': %w", useHelmChartVersion, err)
 		}
 
 		// Parse existing chart version.
@@ -489,7 +489,7 @@ func (o *deployGameServerOpts) Run(cmd *cobra.Command) error {
 			})
 			err := helmutil.UninstallRelease(actionConfig, existingRelease)
 			if err != nil {
-				return fmt.Errorf("failed to uninstall Helm release %s: %v", existingRelease.Name, err)
+				return fmt.Errorf("failed to uninstall Helm release %s: %w", existingRelease.Name, err)
 			}
 			existingRelease = nil // Mark as uninstalled, so deploy doesn't try to upgrade
 			return nil

--- a/cmd/dev_server.go
+++ b/cmd/dev_server.go
@@ -91,18 +91,18 @@ func (o *devServerOpts) Run(cmd *cobra.Command) error {
 		// Run with file watching (auto-restart on code changes).
 		watchArgs := append([]string{"watch", "run", "--no-hot-reload", "/p:Configuration=Watch"}, o.extraArgs...)
 		if err := execChildInteractive(ctx, serverPath, "dotnet", watchArgs, commonDotnetEnvVars); err != nil {
-			return fmt.Errorf("game server exited with error: %s", err)
+			return fmt.Errorf("game server exited with error: %w", err)
 		}
 	} else {
 		// Build the game server .NET project.
 		if err := execChildInteractive(ctx, serverPath, "dotnet", []string{"build"}, commonDotnetEnvVars); err != nil {
-			return fmt.Errorf("failed to build the game server .NET project: %s", err)
+			return fmt.Errorf("failed to build the game server .NET project: %w", err)
 		}
 
 		// Run the game server (skip build).
 		runArgs := append([]string{"run", "--no-build"}, o.extraArgs...)
 		if err := execChildInteractive(ctx, serverPath, "dotnet", runArgs, commonDotnetEnvVars); err != nil {
-			return fmt.Errorf("game server exited with error: %s", err)
+			return fmt.Errorf("game server exited with error: %w", err)
 		}
 	}
 

--- a/cmd/dotnet_helper.go
+++ b/cmd/dotnet_helper.go
@@ -95,7 +95,7 @@ func checkDotnetSdkVersion(ctx context.Context, requiredDotnetVersion *version.V
 	installedVersionStr := strings.TrimSpace(out.String())
 	installedVersion, err := version.NewVersion(installedVersionStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse required .NET version string '%s': %v", installedVersionStr, err)
+		return fmt.Errorf("failed to parse required .NET version string '%s': %w", installedVersionStr, err)
 	}
 
 	// Print the info.

--- a/cmd/get_aws_credentials.go
+++ b/cmd/get_aws_credentials.go
@@ -108,7 +108,7 @@ func (o *getAWSCredentialsOpts) Run(cmd *cobra.Command) error {
 	case "json":
 		output, err := json.MarshalIndent(credentials, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal credentials to JSON: %v", err)
+			return fmt.Errorf("failed to marshal credentials to JSON: %w", err)
 		}
 		fmt.Println(string(output))
 	case "text":

--- a/cmd/get_kubeconfig.go
+++ b/cmd/get_kubeconfig.go
@@ -143,7 +143,7 @@ func (o *getKubeConfigOpts) Run(cmd *cobra.Command) error {
 		log.Debug().Msgf("Write kubeconfig to file %s", o.flagOutput)
 		err = os.WriteFile(o.flagOutput, []byte(kubeconfigPayload), 0600)
 		if err != nil {
-			return fmt.Errorf("failed to write kubeconfig to file: %v", err)
+			return fmt.Errorf("failed to write kubeconfig to file: %w", err)
 		}
 		log.Info().Msgf("Wrote kubeconfig to %s", o.flagOutput)
 	} else {

--- a/cmd/init_dashboard.go
+++ b/cmd/init_dashboard.go
@@ -228,13 +228,13 @@ func computeProjectConfigDashboardUpdate(project *metaproj.MetaplayProject, dash
 	projectConfigFilePath := filepath.Join(project.RelativeDir, metaproj.ConfigFileName)
 	configFileBytes, err := os.ReadFile(projectConfigFilePath)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to read project config file: %v", err)
+		return "", nil, fmt.Errorf("failed to read project config file: %w", err)
 	}
 
 	// Parse the YAML to AST
 	root, err := parser.ParseBytes(configFileBytes, parser.ParseComments)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to parse project config file: %v", err)
+		return "", nil, fmt.Errorf("failed to parse project config file: %w", err)
 	}
 
 	// Update features.dashboard with new values.

--- a/cmd/kube_exec_util.go
+++ b/cmd/kube_exec_util.go
@@ -46,7 +46,7 @@ func execRemoteKubernetesCommand(ctx context.Context, restConfig *restclient.Con
 	// Create SPDY executor
 	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", requestURL)
 	if err != nil {
-		return fmt.Errorf("failed to create SPDY executor: %v", err)
+		return fmt.Errorf("failed to create SPDY executor: %w", err)
 	}
 
 	// Helper function for common streaming logic

--- a/cmd/project_ops.go
+++ b/cmd/project_ops.go
@@ -117,7 +117,7 @@ func validateUnityProjectPath(rootPath string, unityProjectPath string) error {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("unity project path does not exist: %s", unityProjectPathAbs)
 		}
-		return fmt.Errorf("error accessing unity project path: %v", err)
+		return fmt.Errorf("error accessing unity project path: %w", err)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("unity project path must be a directory: %s", unityProjectPathAbs)
@@ -137,7 +137,7 @@ func validateUnityProjectPath(rootPath string, unityProjectPath string) error {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("%s does not appear to be a Unity project (no %s found): %s", unityProjectPathAbs, description, path)
 			}
-			return fmt.Errorf("error accessing Unity project's %s: %v", description, err)
+			return fmt.Errorf("error accessing Unity project's %s: %w", description, err)
 		}
 	}
 
@@ -235,7 +235,7 @@ func downloadAndExtractSdk(tokenSet *auth.TokenSet, targetProjectPath string, ve
 	// Validate the SDK archive file.
 	sdkMetadata, err := validateSdkZipFile(sdkZipPath)
 	if err != nil {
-		return fmt.Errorf("invalid Metaplay SDK archive: %v", err)
+		return fmt.Errorf("invalid Metaplay SDK archive: %w", err)
 	}
 	log.Debug().Msgf("Use downloaded SDK archive: %s (v%s)", sdkZipPath, sdkMetadata.SdkVersion)
 
@@ -253,7 +253,7 @@ func resolveSdkSource(targetProjectPath, sdkSource string) (string, *metaproj.Me
 		// Refer (don't copy) to the specified MetaplaySDK directory.
 		relativePathToSdk, err := filepath.Rel(targetProjectPath, sdkSource)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to construct relative path to MetaplaySDK: %v", err)
+			return "", nil, fmt.Errorf("failed to construct relative path to MetaplaySDK: %w", err)
 		}
 
 		// Ensure the SDK directory is valid.
@@ -267,13 +267,13 @@ func resolveSdkSource(targetProjectPath, sdkSource string) (string, *metaproj.Me
 		// Validate the SDK archive file.
 		sdkMetadata, err := validateSdkZipFile(sdkSource)
 		if err != nil {
-			return "", nil, fmt.Errorf("invalid Metaplay SDK archive: %v", err)
+			return "", nil, fmt.Errorf("invalid Metaplay SDK archive: %w", err)
 		}
 		log.Debug().Msgf("Use local SDK archive file: %s (v%s)", sdkSource, sdkMetadata.SdkVersion)
 
 		// Extract SDK into target directory.
 		if err := extractSdkFromZip(targetProjectPath, sdkSource); err != nil {
-			return "", nil, fmt.Errorf("failed to extract SDK archive: %v", err)
+			return "", nil, fmt.Errorf("failed to extract SDK archive: %w", err)
 		}
 
 		return "MetaplaySDK", sdkMetadata, nil
@@ -299,7 +299,7 @@ func validateSdkZipFile(sdkZipPath string) (*metaproj.MetaplayVersionMetadata, e
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("SDK archive file does not exist: %s", sdkZipPath)
 		}
-		return nil, fmt.Errorf("error accessing SDK archive file: %v", err)
+		return nil, fmt.Errorf("error accessing SDK archive file: %w", err)
 	}
 
 	// Check if it's a regular file (not a directory)
@@ -315,7 +315,7 @@ func validateSdkZipFile(sdkZipPath string) (*metaproj.MetaplayVersionMetadata, e
 	// Open and validate ZIP archive
 	reader, err := zip.OpenReader(sdkZipPath)
 	if err != nil {
-		return nil, fmt.Errorf("invalid ZIP archive: %v", err)
+		return nil, fmt.Errorf("invalid ZIP archive: %w", err)
 	}
 	defer func() { _ = reader.Close() }()
 
@@ -334,13 +334,13 @@ func validateSdkZipFile(sdkZipPath string) (*metaproj.MetaplayVersionMetadata, e
 	// Open and read the version.yaml file
 	rc, err := versionFile.Open()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open version.yaml in ZIP: %v", err)
+		return nil, fmt.Errorf("failed to open version.yaml in ZIP: %w", err)
 	}
 	defer func() { _ = rc.Close() }()
 
 	content, err := io.ReadAll(rc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read version.yaml from ZIP: %v", err)
+		return nil, fmt.Errorf("failed to read version.yaml from ZIP: %w", err)
 	}
 
 	// Parse the version metadata
@@ -358,7 +358,7 @@ func extractSdkFromZip(targetDir string, sdkZipPath string) error {
 	// Open the zip archive
 	reader, err := zip.OpenReader(sdkZipPath)
 	if err != nil {
-		return fmt.Errorf("failed to open ZIP archive: %v", err)
+		return fmt.Errorf("failed to open ZIP archive: %w", err)
 	}
 	defer func() { _ = reader.Close() }()
 
@@ -384,27 +384,27 @@ func extractSdkFromZip(targetDir string, sdkZipPath string) error {
 		if file.FileInfo().IsDir() {
 			// Create directory
 			if err := os.MkdirAll(targetPath, 0755); err != nil {
-				return fmt.Errorf("failed to create directory %s: %v", targetPath, err)
+				return fmt.Errorf("failed to create directory %s: %w", targetPath, err)
 			}
 			continue
 		}
 
 		// Create parent directories if they don't exist
 		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-			return fmt.Errorf("failed to create parent directory for %s: %v", targetPath, err)
+			return fmt.Errorf("failed to create parent directory for %s: %w", targetPath, err)
 		}
 
 		// Create the file
 		outFile, err := os.Create(targetPath)
 		if err != nil {
-			return fmt.Errorf("failed to create file %s: %v", targetPath, err)
+			return fmt.Errorf("failed to create file %s: %w", targetPath, err)
 		}
 
 		// Open the zip file
 		rc, err := file.Open()
 		if err != nil {
 			_ = outFile.Close()
-			return fmt.Errorf("failed to open zip file %s: %v", file.Name, err)
+			return fmt.Errorf("failed to open zip file %s: %w", file.Name, err)
 		}
 
 		// Copy the contents
@@ -412,7 +412,7 @@ func extractSdkFromZip(targetDir string, sdkZipPath string) error {
 		_ = rc.Close()
 		_ = outFile.Close()
 		if err != nil {
-			return fmt.Errorf("failed to write file %s: %v", targetPath, err)
+			return fmt.Errorf("failed to write file %s: %w", targetPath, err)
 		}
 	}
 
@@ -447,7 +447,7 @@ func processTemplateFiles(plan *filesetwriter.Plan, template installerTemplatePr
 		// Resolve destination path (fill in templates)
 		fileDstPath, err := applyReplacements(filepath.Join(dstRoot, file.Path), replacements)
 		if err != nil {
-			return fmt.Errorf("failed to apply replacements to file path %s: %v", file.Path, err)
+			return fmt.Errorf("failed to apply replacements to file path %s: %w", file.Path, err)
 		}
 
 		// Unity .meta files are skipped on conflict to preserve existing GUIDs
@@ -457,7 +457,7 @@ func processTemplateFiles(plan *filesetwriter.Plan, template installerTemplatePr
 		if file.Text != "" {
 			content, err := applyReplacements(file.Text, replacements)
 			if err != nil {
-				return fmt.Errorf("failed to apply replacements to file content %s: %v", file.Path, err)
+				return fmt.Errorf("failed to apply replacements to file content %s: %w", file.Path, err)
 			}
 			if isMetaFile {
 				plan.AddSkipExisting(fileDstPath, []byte(content), 0644)
@@ -467,7 +467,7 @@ func processTemplateFiles(plan *filesetwriter.Plan, template installerTemplatePr
 		} else if file.Bytes != "" {
 			bytes, err := base64.StdEncoding.DecodeString(file.Bytes)
 			if err != nil {
-				return fmt.Errorf("failed to decode base64 string for file %s: %v", fileDstPath, err)
+				return fmt.Errorf("failed to decode base64 string for file %s: %w", fileDstPath, err)
 			}
 			if isMetaFile {
 				plan.AddSkipExisting(fileDstPath, bytes, 0644)
@@ -515,19 +515,19 @@ func collectFromTemplate(plan *filesetwriter.Plan, project *metaproj.MetaplayPro
 	// Resolve path to installer template file
 	templatePath := filepath.Join(project.GetSdkRootDir(), "Installer", templateFileName)
 	if _, err := os.Stat(templatePath); err != nil {
-		return fmt.Errorf("unable to find template file at %s: %v", templatePath, err)
+		return fmt.Errorf("unable to find template file at %s: %w", templatePath, err)
 	}
 
 	// Read the template file
 	templateJSON, err := os.ReadFile(templatePath)
 	if err != nil {
-		return fmt.Errorf("failed to read template file: %v", err)
+		return fmt.Errorf("failed to read template file: %w", err)
 	}
 
 	// Parse the template
 	var template installerTemplateProject
 	if err := json.Unmarshal(templateJSON, &template); err != nil {
-		return fmt.Errorf("failed to parse template file: %v", err)
+		return fmt.Errorf("failed to parse template file: %w", err)
 	}
 
 	if template.Version != 1 {
@@ -550,7 +550,7 @@ func collectFromTemplateInZip(plan *filesetwriter.Plan, zipPath string, template
 	// Open the zip archive.
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return fmt.Errorf("failed to open zip archive: %v", err)
+		return fmt.Errorf("failed to open zip archive: %w", err)
 	}
 	defer func() { _ = reader.Close() }()
 
@@ -570,19 +570,19 @@ func collectFromTemplateInZip(plan *filesetwriter.Plan, zipPath string, template
 	// Read the template JSON from the zip.
 	rc, err := templateFile.Open()
 	if err != nil {
-		return fmt.Errorf("failed to open template file in zip: %v", err)
+		return fmt.Errorf("failed to open template file in zip: %w", err)
 	}
 	defer func() { _ = rc.Close() }()
 
 	templateJSON, err := io.ReadAll(rc)
 	if err != nil {
-		return fmt.Errorf("failed to read template file from zip: %v", err)
+		return fmt.Errorf("failed to read template file from zip: %w", err)
 	}
 
 	// Parse the template.
 	var template installerTemplateProject
 	if err := json.Unmarshal(templateJSON, &template); err != nil {
-		return fmt.Errorf("failed to parse template file: %v", err)
+		return fmt.Errorf("failed to parse template file: %w", err)
 	}
 
 	if template.Version != 1 {

--- a/cmd/remove_server.go
+++ b/cmd/remove_server.go
@@ -88,7 +88,7 @@ func (o *removeGameServerOpts) Run(cmd *cobra.Command) error {
 	// Resolve all deployed game server Helm releases.
 	helmReleases, err := helmutil.HelmListReleases(actionConfig, metaplayGameServerChartName)
 	if err != nil {
-		return fmt.Errorf("failed to resolve existing Helm releases: %v", err)
+		return fmt.Errorf("failed to resolve existing Helm releases: %w", err)
 	}
 
 	// If no releases found, exit.
@@ -112,7 +112,7 @@ func (o *removeGameServerOpts) Run(cmd *cobra.Command) error {
 			})
 			err := helmutil.UninstallRelease(actionConfig, release)
 			if err != nil {
-				return fmt.Errorf("failed to uninstall Helm release %s: %v", release.Name, err)
+				return fmt.Errorf("failed to uninstall Helm release %s: %w", release.Name, err)
 			}
 			return nil
 		})

--- a/cmd/secrets_create.go
+++ b/cmd/secrets_create.go
@@ -128,7 +128,7 @@ func (o *secretsCreateOpts) Prepare(cmd *cobra.Command, args []string) error {
 		// Read the file content
 		fileContent, err := os.ReadFile(filePath)
 		if err != nil {
-			return fmt.Errorf("failed to read secret from file '%s': %v", filePath, err)
+			return fmt.Errorf("failed to read secret from file '%s': %w", filePath, err)
 		}
 
 		// Insert into the map

--- a/cmd/secrets_list.go
+++ b/cmd/secrets_list.go
@@ -103,7 +103,7 @@ func (o *secretsListOpts) Run(cmd *cobra.Command) error {
 	if o.flagFormat == "json" {
 		secretsJSON, err := json.MarshalIndent(secrets, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal secrets as JSON: %v", err)
+			return fmt.Errorf("failed to marshal secrets as JSON: %w", err)
 		}
 
 		log.Info().Msgf("%s", string(secretsJSON))

--- a/cmd/secrets_show.go
+++ b/cmd/secrets_show.go
@@ -101,7 +101,7 @@ func (o *secretsShowOpts) Run(cmd *cobra.Command) error {
 	if o.flagFormat == "json" {
 		secretJSON, err := json.MarshalIndent(secret, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal secrets as JSON: %v", err)
+			return fmt.Errorf("failed to marshal secrets as JSON: %w", err)
 		}
 
 		log.Info().Msgf("%s", string(secretJSON))

--- a/cmd/secrets_update.go
+++ b/cmd/secrets_update.go
@@ -119,7 +119,7 @@ func (o *secretsUpdateOpts) Prepare(cmd *cobra.Command, args []string) error {
 		// Read the file content
 		fileContent, err := os.ReadFile(filePath)
 		if err != nil {
-			return fmt.Errorf("failed to read secret from file '%s': %v", filePath, err)
+			return fmt.Errorf("failed to read secret from file '%s': %w", filePath, err)
 		}
 
 		// Insert into the map

--- a/cmd/update_project_environments.go
+++ b/cmd/update_project_environments.go
@@ -113,7 +113,7 @@ func (o *updateProjectEnvironmentsOpts) updateProjectConfigEnvironments(project 
 	projectConfigFilePath := filepath.Join(project.RelativeDir, metaproj.ConfigFileName)
 	configFileBytes, err := os.ReadFile(projectConfigFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to read project config file: %v", err)
+		return fmt.Errorf("failed to read project config file: %w", err)
 	}
 
 	root, err := parser.ParseBytes(configFileBytes, parser.ParseComments)
@@ -124,13 +124,13 @@ func (o *updateProjectEnvironmentsOpts) updateProjectConfigEnvironments(project 
 	// Find the 'environments' node -- should be an array but can also be null
 	envsPath, err := yaml.PathString("$.environments")
 	if err != nil {
-		return fmt.Errorf("failed to create environments path: %v", err)
+		return fmt.Errorf("failed to create environments path: %w", err)
 	}
 
 	// Get the environments node
 	envsNode, err := envsPath.FilterFile(root)
 	if err != nil {
-		return fmt.Errorf("failed to find 'environments' in metaplay-project.yaml: %v", err)
+		return fmt.Errorf("failed to find 'environments' in metaplay-project.yaml: %w", err)
 	}
 
 	// Handle the case where environments exists but is null/empty (e.g., "environments:" with no value).
@@ -147,12 +147,12 @@ func (o *updateProjectEnvironmentsOpts) updateProjectConfigEnvironments(project 
 
 		// Replace the null node with an empty sequence
 		if err := envsPath.ReplaceWithReader(root, strings.NewReader("[]")); err != nil {
-			return fmt.Errorf("failed to replace null 'environments' with empty sequence: %v", err)
+			return fmt.Errorf("failed to replace null 'environments' with empty sequence: %w", err)
 		}
 		// Re-fetch the environments node after replacement
 		envsNode, err = envsPath.FilterFile(root)
 		if err != nil {
-			return fmt.Errorf("failed to find node 'environments' after replacement: %v", err)
+			return fmt.Errorf("failed to find node 'environments' after replacement: %w", err)
 		}
 		// Ensure block-style output (not flow-style like [a, b, c]) and reset indentation
 		if seqNode, ok := envsNode.(*ast.SequenceNode); ok {
@@ -266,7 +266,7 @@ func (o *updateProjectEnvironmentsOpts) updateProjectConfigEnvironments(project 
 
 	// Write the updated YAML back to the file
 	if err := os.WriteFile(projectConfigFilePath, []byte(root.String()), 0644); err != nil {
-		return fmt.Errorf("failed to write updated config: %v", err)
+		return fmt.Errorf("failed to write updated config: %w", err)
 	}
 
 	log.Info().Msg("")

--- a/internal/pathutil/windows.go
+++ b/internal/pathutil/windows.go
@@ -55,7 +55,7 @@ func GetExecutablePath() (string, error) {
 
 	file, err := os.Open(exe)
 	if err != nil {
-		return "", fmt.Errorf("failed to open the executable file: %v", err)
+		return "", fmt.Errorf("failed to open the executable file: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 
@@ -72,7 +72,7 @@ func GetExecutablePath() (string, error) {
 	buf := make([]uint16, bufSize)
 	n, err := windows.GetFinalPathNameByHandle(handle, &buf[0], uint32(len(buf)), 0)
 	if err != nil {
-		return "", fmt.Errorf("failed to get the final path name by handle: %v", err)
+		return "", fmt.Errorf("failed to get the final path name by handle: %w", err)
 	}
 
 	// Convert the buffer to a string

--- a/internal/tui/confirm_dialog.go
+++ b/internal/tui/confirm_dialog.go
@@ -73,7 +73,7 @@ func DoConfirmDialog(ctx context.Context, title string, body string, question st
 	p := tea.NewProgram(newConfirmDialog(ctx, title, body, question))
 	m, err := p.Run()
 	if err != nil {
-		return false, fmt.Errorf("failed to run confirmation dialog: %v", err)
+		return false, fmt.Errorf("failed to run confirmation dialog: %w", err)
 	}
 
 	return m.(confirmDialog).choice, nil

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -95,6 +95,8 @@ func removeStaleUpdateFiles(exePath string) error {
 		case err == nil:
 			log.Debug().Msgf("Removed %s left over from an earlier update", path)
 		case !errors.Is(err, fs.ErrNotExist):
+			// %v, not %w, on the errno: keeping it out of the chain is the whole point
+			// of ErrLeftoverInUse, and assertBlockedLeftover pins that contract.
 			errs = append(errs, fmt.Errorf("%w: %s: %v",
 				ErrLeftoverInUse, pathutil.ForDisplay(path), unwrapPathError(err)))
 		}

--- a/pkg/auth/login.go
+++ b/pkg/auth/login.go
@@ -83,7 +83,7 @@ func LoginWithBrowser(ctx context.Context, authProvider *AuthProviderConfig) err
 	// Generate a random state for login.
 	state, err := generateRandomString(16)
 	if err != nil {
-		return fmt.Errorf("failed to generate random state: %v", err)
+		return fmt.Errorf("failed to generate random state: %w", err)
 	}
 
 	// Create a channel to signal server shutdown.

--- a/pkg/envapi/new_gameserver_cr.go
+++ b/pkg/envapi/new_gameserver_cr.go
@@ -106,13 +106,13 @@ func getGameServerNewCR(ctx context.Context, kubeCli *KubeClient) (*NewGameServe
 	// Convert unstructured object to JSON
 	gameServerJSON, err := unstructuredObj.MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal NewGameServerCR to JSON: %v", err)
+		return nil, fmt.Errorf("failed to marshal NewGameServerCR to JSON: %w", err)
 	}
 
 	// Parse JSON into structured Go struct
 	var gameServerCR NewGameServerCR
 	if err := json.Unmarshal(gameServerJSON, &gameServerCR); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal NewGameServerCR: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal NewGameServerCR: %w", err)
 	}
 
 	// Output parsed NewGameServerCR struct

--- a/pkg/envapi/old_gameserver_cr.go
+++ b/pkg/envapi/old_gameserver_cr.go
@@ -65,13 +65,13 @@ func getGameServerOldCR(ctx context.Context, kubeCli *KubeClient) (*OldGameServe
 	// Convert unstructured object to JSON
 	gameServerJSON, err := unstructuredObj.MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal OldGameServerCR to JSON: %v", err)
+		return nil, fmt.Errorf("failed to marshal OldGameServerCR to JSON: %w", err)
 	}
 
 	// Parse JSON into structured Go struct
 	var gameServerCR OldGameServerCR
 	if err := json.Unmarshal(gameServerJSON, &gameServerCR); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal OldGameServerCR: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal OldGameServerCR: %w", err)
 	}
 
 	// Output parsed OldGameServerCR struct

--- a/pkg/envapi/target_environment.go
+++ b/pkg/envapi/target_environment.go
@@ -365,7 +365,7 @@ func (target *TargetEnvironment) newECRClient(envDetails *DeploymentSecret) (*ec
 	log.Debug().Msg("Get AWS credentials")
 	awsCredentials, err := target.GetAWSCredentials()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get AWS credentials: %v", err)
+		return nil, fmt.Errorf("failed to get AWS credentials: %w", err)
 	}
 
 	log.Debug().Msg("Create AWS config")

--- a/pkg/envapi/wait_server_ready.go
+++ b/pkg/envapi/wait_server_ready.go
@@ -548,7 +548,7 @@ func waitForDomainResolution(output *tui.TaskOutput, hostname string, timeout ti
 			return fmt.Errorf("could not resolve domain %s before timeout", hostname)
 		}
 
-		if dnsErr, ok := err.(*net.DNSError); ok && dnsErr.IsNotFound {
+		if dnsErr, ok := errors.AsType[*net.DNSError](err); ok && dnsErr.IsNotFound {
 			output.AppendLinef("Attempt %d failed: %v", attemptNdx+1, dnsErr)
 		} else {
 			output.AppendLinef("Failed to resolve %s: %v. Retrying...", hostname, err)
@@ -613,7 +613,7 @@ func attemptTLSConnection(hostname string, port int) error {
 		ServerName: hostname,
 	})
 	if err != nil {
-		return fmt.Errorf("TLS connection failed: %v", err)
+		return fmt.Errorf("TLS connection failed: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
 
@@ -623,7 +623,7 @@ func attemptTLSConnection(hostname string, port int) error {
 	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	healthCheckPacket := buildHealthCheckPacket()
 	if _, err := conn.Write(healthCheckPacket); err != nil {
-		return fmt.Errorf("failed to send HealthCheck packet: %v", err)
+		return fmt.Errorf("failed to send HealthCheck packet: %w", err)
 	}
 
 	// Read the protocol header from the server.
@@ -634,7 +634,7 @@ func attemptTLSConnection(hostname string, port int) error {
 	for totalRead < protocolHeaderSize {
 		n, err := conn.Read(buffer[totalRead:])
 		if err != nil {
-			return fmt.Errorf("error reading protocol header from server (got %d/%d bytes): %v", totalRead, protocolHeaderSize, err)
+			return fmt.Errorf("error reading protocol header from server (got %d/%d bytes): %w", totalRead, protocolHeaderSize, err)
 		}
 		totalRead += n
 	}
@@ -649,12 +649,12 @@ func attemptTLSConnection(hostname string, port int) error {
 	// Parse and validate the protocol header.
 	header, err := parseProtocolHeader(buffer[:totalRead])
 	if err != nil {
-		return fmt.Errorf("failed to parse protocol header: %v", err)
+		return fmt.Errorf("failed to parse protocol header: %w", err)
 	}
 	log.Debug().Msgf("Protocol header: version=%d, status=%d, magic=%x", header.Version, header.Status, header.Magic)
 
 	if err := validateProtocolHeader(header); err != nil {
-		return fmt.Errorf("protocol header validation failed: %v", err)
+		return fmt.Errorf("protocol header validation failed: %w", err)
 	}
 
 	return nil

--- a/pkg/helmutil/chart_repository.go
+++ b/pkg/helmutil/chart_repository.go
@@ -44,7 +44,7 @@ func ValidateLocalHelmChart(helmChartLocalPath string) error {
 	var chart HelmChart
 	err = yaml.Unmarshal(chartBytes, &chart)
 	if err != nil {
-		return fmt.Errorf("failed to parse Chart.yaml: %v", err)
+		return fmt.Errorf("failed to parse Chart.yaml: %w", err)
 	}
 
 	// Chart name must be 'metaplay-gameserver'.
@@ -147,14 +147,14 @@ func ResolveBestMatchingHelmVersion(helmChartRepo, chartName string, legacyVersi
 	helmChartRepo = strings.TrimSuffix(helmChartRepo, "/")
 	availableChartVersions, err := FetchHelmChartVersions(helmChartRepo, chartName, legacyVersionCutoff)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch Helm chart versions from the repository: %v", err)
+		return "", fmt.Errorf("failed to fetch Helm chart versions from the repository: %w", err)
 	}
 	log.Debug().Msgf("Available Helm chart versions in repository: %v", strings.Join(availableChartVersions, ", "))
 
 	// Find the best version match that is the latest one from the versions satisfying the requested version(s).
 	useChartVersion, err := ResolveBestMatchingVersion(availableChartVersions, versionConstraints)
 	if err != nil {
-		return "", fmt.Errorf("failed to find a matching Helm chart version: %v", err)
+		return "", fmt.Errorf("failed to find a matching Helm chart version: %w", err)
 	}
 
 	return useChartVersion, nil

--- a/pkg/helmutil/get_existing_release.go
+++ b/pkg/helmutil/get_existing_release.go
@@ -23,7 +23,7 @@ func GetExistingRelease(actionConfig *action.Configuration, chartName string) (*
 	// Find all releases of the chart deployed in the environment.
 	releases, err := HelmListReleases(actionConfig, chartName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve existing Helm releases: %v", err)
+		return nil, fmt.Errorf("failed to resolve existing Helm releases: %w", err)
 	}
 
 	// Handle no found releases.

--- a/pkg/kubeutil/debug_container.go
+++ b/pkg/kubeutil/debug_container.go
@@ -35,7 +35,7 @@ func CreateDebugContainer(ctx context.Context, kubeCli *envapi.KubeClient, podNa
 	// Resolve target pod.
 	pod, err := kubeCli.Clientset.CoreV1().Pods(kubeCli.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to get target pod %s: %v", podName, err)
+		return "", nil, fmt.Errorf("failed to get target pod %s: %w", podName, err)
 	}
 
 	// Verify target container exists
@@ -215,7 +215,7 @@ func waitForContainerReady(ctx context.Context, kubeCli *envapi.KubeClient, podN
 	})
 
 	if err != nil {
-		return fmt.Errorf("error waiting for container: %v", err)
+		return fmt.Errorf("error waiting for container: %w", err)
 	}
 
 	return nil

--- a/pkg/kubeutil/file_copy.go
+++ b/pkg/kubeutil/file_copy.go
@@ -292,7 +292,7 @@ func streamFileFromPod(ctx context.Context, kubeCli *envapi.KubeClient, podName,
 		// Create gzip reader for decompression
 		gzReader, err := gzip.NewReader(reader)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("failed to create gzip reader: %v", err)
+			return nil, nil, 0, fmt.Errorf("failed to create gzip reader: %w", err)
 		}
 		tarReader = tar.NewReader(gzReader)
 		closer = func() error { return gzReader.Close() }
@@ -310,7 +310,7 @@ func streamFileFromPod(ctx context.Context, kubeCli *envapi.KubeClient, podName,
 		}
 		if err != nil {
 			_ = closer()
-			return nil, nil, 0, fmt.Errorf("failed to read tar header: %v", err)
+			return nil, nil, 0, fmt.Errorf("failed to read tar header: %w", err)
 		}
 		if hdr.Name != filepath.Base(fileName) {
 			continue
@@ -351,7 +351,7 @@ func attemptResumableFileCopy(ctx context.Context, output *tui.TaskOutput, kubeC
 		destFile, err = os.Create(destPath)
 	}
 	if err != nil {
-		return 0, fmt.Errorf("failed to create destination file: %v", err)
+		return 0, fmt.Errorf("failed to create destination file: %w", err)
 	}
 	defer func() { _ = destFile.Close() }()
 
@@ -447,7 +447,7 @@ func CopyFileFromDebugPod(ctx context.Context, output *tui.TaskOutput, kubeCli *
 	// Create the destination directory if it doesn't exist
 	destDir := filepath.Dir(destPath)
 	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return fmt.Errorf("failed to create destination directory: %v", err)
+		return fmt.Errorf("failed to create destination directory: %w", err)
 	}
 
 	// Use forward slash for remote Linux path (not filepath.Join which uses OS-specific separators)

--- a/pkg/kubeutil/process_info.go
+++ b/pkg/kubeutil/process_info.go
@@ -65,7 +65,7 @@ func GetServerProcessInformation(ctx context.Context, kubeCli *envapi.KubeClient
 
 	// Validate that the username follows Unix/Linux username conventions
 	if err := validateUnixUsername(username); err != nil {
-		return nil, fmt.Errorf("invalid username '%s': %v", username, err)
+		return nil, fmt.Errorf("invalid username '%s': %w", username, err)
 	}
 	log.Debug().Msgf("Game server is running as user: %s", username)
 

--- a/pkg/metaproj/metaplay_project.go
+++ b/pkg/metaproj/metaplay_project.go
@@ -157,13 +157,13 @@ func LoadProjectConfigFile(projectDir string) (*ProjectConfig, error) {
 	// Apply defaults to project config.
 	err = ApplyProjectConfigDefaults(&projectConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to apply defaults to metaplay-project.yaml: %v", err)
+		return nil, fmt.Errorf("failed to apply defaults to metaplay-project.yaml: %w", err)
 	}
 
 	// Validate the project config.
 	err = ValidateProjectConfig(projectDir, &projectConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate metaplay-project.yaml: %v", err)
+		return nil, fmt.Errorf("failed to validate metaplay-project.yaml: %w", err)
 	}
 
 	return &projectConfig, nil
@@ -333,7 +333,7 @@ func ValidateProjectConfig(projectDir string, config *ProjectConfig) error {
 			}
 			parsedURL, err := url.Parse(endpoint)
 			if err != nil {
-				return fmt.Errorf("authProviders[%s].%s is not a valid URL: %v", name, endpointName, err)
+				return fmt.Errorf("authProviders[%s].%s is not a valid URL: %w", name, endpointName, err)
 			}
 			if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 				return fmt.Errorf("authProviders[%s].%s must use http or https scheme", name, endpointName)
@@ -539,7 +539,7 @@ func LoadSdkVersionMetadata(sdkRootDir string) (*MetaplayVersionMetadata, error)
 		}
 
 		// Generic error when we don't know what went wrong.
-		return nil, fmt.Errorf("failed to read Metaplay SDK version metadata: %v", readVersionErr)
+		return nil, fmt.Errorf("failed to read Metaplay SDK version metadata: %w", readVersionErr)
 	}
 
 	// Parse and validate the 'version.yaml' contents.

--- a/pkg/testutil/background_game_server.go
+++ b/pkg/testutil/background_game_server.go
@@ -447,7 +447,7 @@ func removeDockerContainerByName(ctx context.Context, name string) error {
 	cmd := exec.CommandContext(ctx, "docker", "rm", "-f", name)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("docker rm -f %s failed: %v, output: %s", name, err, string(output))
+		return fmt.Errorf("docker rm -f %s failed: %w, output: %s", name, err, string(output))
 	}
 	return nil
 }


### PR DESCRIPTION
143 `fmt.Errorf` calls flattened their cause to a string with `%v`, so `errors.Is` and `errors.AsType` could not see through them. #165 moved error extraction to `errors.AsType`; this makes there be something to extract.

Produced with `golangci-lint run -E errorlint --fix`, then reviewed line by line. **The auto-fix got three things wrong**, which is the interesting part of this PR:

## 1. It dropped a condition while rewriting a type assertion

In `waitForDomainResolution` (`pkg/envapi/wait_server_ready.go`):

```go
-if dnsErr, ok := err.(*net.DNSError); ok && dnsErr.IsNotFound {
+dnsErr := &net.DNSError{}
+if errors.As(err, &dnsErr) {
```

The `&& dnsErr.IsNotFound` guard vanished, which would have taken the not-found branch for *every* `*net.DNSError` including timeouts and temporary failures, changing which message the user sees on a retry. Rewritten by hand as `errors.AsType[*net.DNSError]` with the check intact — which also gets the unwrap-awareness errorlint was actually after.

## 2. It weakened seven test assertions

It changed `err.Cause != cause` to `errors.Is(err.Cause, cause)` in `internal/errors/cli_error_test.go` and `cmd/llm_docs_test.go`. Those assertions pin that the `Cause` field holds *exactly* the error passed in; `errors.Is` also passes if `Cause` merely wraps it. `TestUnwrap` is the clearest case — verifying the identity of the unwrapped value is the entire point of the test. Substituting `errors.Is` would also be circular: it would verify `CLIError.Unwrap` by calling `CLIError.Unwrap`. All seven reverted.

## 3. It broke a documented contract, and the test suite caught it

`removeStaleUpdateFiles` in `internal/version/update.go` deliberately uses `%v` on the errno. Its doc comment says so, and `assertBlockedLeftover` pins it:

```go
assert.NotErrorIs(t, err, fs.ErrPermission,
    "a blocked leftover must not look like an unwritable install, or the hint tells the user to elevate")
```

Per the comment on that helper, getting this wrong is what previously made the CLI tell users to re-run elevated for a mapped-image file that no privilege level can delete. Reverted, with the reason now on the line itself so the next `--fix` run doesn't redo it.

The mechanism is worth recording: with `%w` on the errno the format string has two `%w` verbs, so `fmt.Errorf` returns a `*fmt.wrapErrors` whose `Unwrap() []error` makes `errors.Is` traverse *both* branches. `unwrapPathError` strips the `*fs.PathError` down to the raw `syscall.Errno`, which implements `Is` mapping `EACCES` / `ERROR_ACCESS_DENIED` to `fs.ErrPermission`. That is exactly how `NotErrorIs` flips.

## Behavior audit

Repairing error chains means `errors.Is` can newly match, so every sentinel check reachable from these lines was traced. **Two real behavior changes**, both believed to be improvements but neither a pure refactor:

### `*CLIError` is newly reachable from project loading

`LoadProjectConfigFile` (`pkg/metaproj/metaplay_project.go:166`) now wraps `ValidateProjectConfig`, which returns a `*CLIError` at three sites — missing or invalid `dotnetRuntimeVersion`, each carrying a `WithSuggestion`. `AsCLIError` therefore succeeds where it previously failed. Verified by building both revisions against a project with `dotnetRuntimeVersion` omitted:

```
main:  Error: failed to validate metaplay-project.yaml: Missing dotnetRuntimeVersion in project config
PR:    Error: Missing dotnetRuntimeVersion in project config
       Hint: Specify the 'major.minor' .NET runtime framework version to use, e.g. '10.0'
```

- `displayError` (`root.go:430`) prints `cliErr.Message` instead of `err.Error()`, so the wrapping context drops and the hint surfaces. This reaches every command that loads the project (~50, via `resolveProject` / `tryResolveProject`).
- `root.go:357` stops printing the usage block, since `!isCLIError(err)` no longer fires. `cmd/init_ci.go:117` is the only command that loads the project from `Prepare()`, so it is the only one affected.
- **Exit codes are unchanged.** All three sites use `clierrors.New` / `Newf` → `ExitRuntime`; none is a `NewUsageError`, so `GetExitCode` and `IsUsageError` are untouched.

### `*SignaledError` is newly reachable from `dev server`

`cmd/dev_server.go:94,99,105` now expose the `*SignaledError` from `execChildInteractive` to `wasInterrupted` (`root.go:399`), which prints `Canceled.` and exits 130 rather than printing an error and exiting 1. Reachable only in the race where the child dies before `signal.NotifyContext` records cancellation — the defensive case `root.go:390` documents. Every other `execChildInteractive` caller already uses `clierrors.Wrap`, which preserved the chain, so this aligns `dev server` with the rest rather than diverging.

### Checked and confirmed inert

- `internal/pathutil/windows.go` now puts `syscall.Errno` (→ `fs.ErrPermission`) in the chain, but the only consumer, `replaceFailureError` (`cmd/update_cli.go:47`), is never called with `GetExecutablePath`'s error.
- `errors.Is(copyErr, io.ErrUnexpectedEOF)` (`file_copy.go:419`) — `copyErr` comes from `io.Copy`, which these lines do not feed; it drives a debug log, not the retry decision, which keys off byte progress.
- `pkg/metaproj/metaplay_project.go:542` puts `fs.ErrNotExist` in the chain, but no caller of `LoadSdkVersionMetadata` inspects it.
- Helm / k8s / metahttp / AWS / Docker sites cannot produce a `*CLIError`.
- Only two `Unwrap()` implementations exist repo-wide (`CLIError`, `SignaledError`); both are covered above. No negative sentinel assertion (`!errors.Is(...)` as a guard) exists that a newly-wrapped error could now satisfy.

## Verification

- `go test ./...` fully passing, 18/18 packages — it failed first, on exactly finding #3
- `make lint` 0 issues, `go vet` clean (no `printf` diagnostics), `gofmt` clean
- 8 `errorlint` findings remain, and they are precisely the ones kept on purpose: the 7 test comparisons and the `update.go` errno
- Every added line in the diff contains `%w` except two: the `IsNotFound` assertion and its explanatory comment
