### PR TITLE
Enforce error wrapping with errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,21 @@
 version: "2"
 
-# The default linter set (errcheck, govet, ineffassign, staticcheck, unused)
-# is unchanged. This file exists to enforce gofmt: CI runs golangci-lint
-# rather than 'make lint', so nothing was catching formatting drift.
+linters:
+  # Standard set (errcheck, govet, ineffassign, staticcheck, unused), plus:
+  enable:
+    # '%v' on an error flattens it to text, so errors.Is/AsType can no longer
+    # see it. Deliberate exceptions carry a //nolint:errorlint saying why.
+    - errorlint
+
 formatters:
+  # CI runs golangci-lint, not 'make lint', so this file is what catches drift.
+  # Note this enforces 'gofmt -s', stricter than a plain gofmt-on-save; run
+  # 'make fix' to apply it.
   enable:
     - gofmt
 
 issues:
-  # Report every occurrence. The defaults (50 per linter, 3 per distinct
-  # message) silently truncate, which reads as "that's all of them" when
-  # it isn't -- the gofmt check hid a file on its first run.
+  # By default only 50 issues per linter and 3 per message are shown. That
+  # truncates silently, which reads as "that's all of them". Show everything.
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,14 @@ through them. CI enforces this via `errorlint`. A handful of sites deliberately
 flatten the cause and carry a `//nolint:errorlint` explaining why — read
 `internal/version/update.go` first, where flattening is load-bearing and a test pins it.
 
-Review `golangci-lint --fix` output hunk by hunk; never take it on trust. Its errorlint
-fixer has dropped a condition while rewriting a type assertion, loosened tests from
-"this exact error" to "somewhere in the chain", and broken a documented `%v` contract.
+`errorlint` only checks `fmt.Errorf`. It cannot see the format strings of
+`clierrors.Newf`/`Wrapf`/`NewUsageErrorf`, so a `%v` on an error there passes CI
+silently. Those need the same care by hand.
+
+Review `golangci-lint run --fix` output hunk by hunk; never take it on trust. Its
+errorlint fixer has dropped a condition while rewriting a type assertion, loosened tests
+from "this exact error" to "somewhere in the chain", and broken a documented `%v`
+contract.
 
 When adding a `%w`, check whether the wrapped error can be a `*CLIError`. If it can,
 `displayError` starts printing that error's message instead of the outer one, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,21 @@ return clierrors.Wrap(err, "Failed to connect to Docker").
 - Use `WithDetails()` for extra context (valid values, available options, etc.)
 - Keep messages concise and capitalize the first word
 
+### Error Wrapping
+
+Wrap causes with `%w`, never `%v` or `%s`, so `errors.Is`/`errors.AsType` can see
+through them. CI enforces this via `errorlint`. A handful of sites deliberately
+flatten the cause and carry a `//nolint:errorlint` explaining why — read
+`internal/version/update.go` first, where flattening is load-bearing and a test pins it.
+
+Review `golangci-lint --fix` output hunk by hunk; never take it on trust. Its errorlint
+fixer has dropped a condition while rewriting a type assertion, loosened tests from
+"this exact error" to "somewhere in the chain", and broken a documented `%v` contract.
+
+When adding a `%w`, check whether the wrapped error can be a `*CLIError`. If it can,
+`displayError` starts printing that error's message instead of the outer one, and
+usage help stops being shown.
+
 ### Interactive Mode
 The CLI auto-detects CI environments and disables interactive mode when:
 - No terminal is available

--- a/cmd/llm_docs_test.go
+++ b/cmd/llm_docs_test.go
@@ -136,6 +136,7 @@ func TestWrapLLMDocsError(t *testing.T) {
 		if !strings.Contains(cliErr.Message, "read file") {
 			t.Errorf("message missing action: %q", cliErr.Message)
 		}
+		//nolint:errorlint // Wants this exact error, not merely one in its chain.
 		if cliErr.Cause != cause {
 			t.Errorf("cause not preserved, got %v", cliErr.Cause)
 		}

--- a/internal/errors/cli_error_test.go
+++ b/internal/errors/cli_error_test.go
@@ -35,8 +35,8 @@ func TestWrap(t *testing.T) {
 	if err.Error() != "operation failed" {
 		t.Errorf("expected 'operation failed', got '%s'", err.Error())
 	}
-	//nolint:errorlint // Wants this exact error, not merely one in its chain.
-	// errors.Is here would test Unwrap by calling Unwrap.
+	//nolint:errorlint // Wants this exact error, not merely one in its chain:
+	// errors.Is would also pass if Cause held something that wraps it.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}
@@ -49,8 +49,8 @@ func TestWrapf(t *testing.T) {
 	if err.Error() != "failed to connect to server" {
 		t.Errorf("expected formatted message, got '%s'", err.Error())
 	}
-	//nolint:errorlint // Wants this exact error, not merely one in its chain.
-	// errors.Is here would test Unwrap by calling Unwrap.
+	//nolint:errorlint // Wants this exact error, not merely one in its chain:
+	// errors.Is would also pass if Cause held something that wraps it.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}
@@ -108,8 +108,8 @@ func TestWithDetails(t *testing.T) {
 func TestWithCause(t *testing.T) {
 	cause := fmt.Errorf("io error")
 	err := New("read failed").WithCause(cause)
-	//nolint:errorlint // Wants this exact error, not merely one in its chain.
-	// errors.Is here would test Unwrap by calling Unwrap.
+	//nolint:errorlint // Wants this exact error, not merely one in its chain:
+	// errors.Is would also pass if Cause held something that wraps it.
 	if err.Cause != cause {
 		t.Error("expected cause to be set via WithCause")
 	}
@@ -145,8 +145,8 @@ func TestWrapUsageError(t *testing.T) {
 	if !err.IsUsageError() {
 		t.Error("expected IsUsageError to be true")
 	}
-	//nolint:errorlint // Wants this exact error, not merely one in its chain.
-	// errors.Is here would test Unwrap by calling Unwrap.
+	//nolint:errorlint // Wants this exact error, not merely one in its chain:
+	// errors.Is would also pass if Cause held something that wraps it.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}
@@ -219,8 +219,8 @@ func TestBuilderChaining(t *testing.T) {
 	if err.Message != "problem" {
 		t.Errorf("expected 'problem', got '%s'", err.Message)
 	}
-	//nolint:errorlint // Wants this exact error, not merely one in its chain.
-	// errors.Is here would test Unwrap by calling Unwrap.
+	//nolint:errorlint // Wants this exact error, not merely one in its chain:
+	// errors.Is would also pass if Cause held something that wraps it.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}

--- a/internal/errors/cli_error_test.go
+++ b/internal/errors/cli_error_test.go
@@ -35,6 +35,8 @@ func TestWrap(t *testing.T) {
 	if err.Error() != "operation failed" {
 		t.Errorf("expected 'operation failed', got '%s'", err.Error())
 	}
+	//nolint:errorlint // Wants this exact error, not merely one in its chain.
+	// errors.Is here would test Unwrap by calling Unwrap.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}
@@ -47,6 +49,8 @@ func TestWrapf(t *testing.T) {
 	if err.Error() != "failed to connect to server" {
 		t.Errorf("expected formatted message, got '%s'", err.Error())
 	}
+	//nolint:errorlint // Wants this exact error, not merely one in its chain.
+	// errors.Is here would test Unwrap by calling Unwrap.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}
@@ -57,6 +61,8 @@ func TestUnwrap(t *testing.T) {
 	err := Wrap(cause, "wrapper")
 
 	unwrapped := errors.Unwrap(err)
+	//nolint:errorlint // Unwrap must return this exact error. errors.Is would
+	// pass even if it found the cause by some other route.
 	if unwrapped != cause {
 		t.Error("Unwrap should return the cause")
 	}
@@ -102,6 +108,8 @@ func TestWithDetails(t *testing.T) {
 func TestWithCause(t *testing.T) {
 	cause := fmt.Errorf("io error")
 	err := New("read failed").WithCause(cause)
+	//nolint:errorlint // Wants this exact error, not merely one in its chain.
+	// errors.Is here would test Unwrap by calling Unwrap.
 	if err.Cause != cause {
 		t.Error("expected cause to be set via WithCause")
 	}
@@ -137,6 +145,8 @@ func TestWrapUsageError(t *testing.T) {
 	if !err.IsUsageError() {
 		t.Error("expected IsUsageError to be true")
 	}
+	//nolint:errorlint // Wants this exact error, not merely one in its chain.
+	// errors.Is here would test Unwrap by calling Unwrap.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}
@@ -209,6 +219,8 @@ func TestBuilderChaining(t *testing.T) {
 	if err.Message != "problem" {
 		t.Errorf("expected 'problem', got '%s'", err.Message)
 	}
+	//nolint:errorlint // Wants this exact error, not merely one in its chain.
+	// errors.Is here would test Unwrap by calling Unwrap.
 	if err.Cause != cause {
 		t.Error("expected cause to be set")
 	}

--- a/internal/version/update.go
+++ b/internal/version/update.go
@@ -95,8 +95,8 @@ func removeStaleUpdateFiles(exePath string) error {
 		case err == nil:
 			log.Debug().Msgf("Removed %s left over from an earlier update", path)
 		case !errors.Is(err, fs.ErrNotExist):
-			// %v, not %w, on the errno: keeping it out of the chain is the whole point
-			// of ErrLeftoverInUse, and assertBlockedLeftover pins that contract.
+			//nolint:errorlint // %v on purpose. Keeping the errno out of the chain is
+			// the point of ErrLeftoverInUse; assertBlockedLeftover pins that.
 			errs = append(errs, fmt.Errorf("%w: %s: %v",
 				ErrLeftoverInUse, pathutil.ForDisplay(path), unwrapPathError(err)))
 		}


### PR DESCRIPTION
#167 changed 143 `fmt.Errorf` calls from `%v` to `%w` so `errors.Is` and `errors.AsType` could see through them. Nothing stopped that regressing: `errorlint` was not enabled, so a stray `%v` on an error would land silently, and the eight sites that flatten deliberately looked like oversights rather than decisions.

## Enable errorlint in CI

`.golangci.yml` is what actually gates PRs — `golangci-lint-action` runs at the repo root with no `args` and no `working-directory`, so it reads this file. `make lint` uses the same pinned v2.12.2, so local and CI agree.

Verified the guard *bites* rather than merely parses. Dropping a probe file into `internal/version`:

```go
func lintProbe(err error) error {
	return fmt.Errorf("flattened: %v", err)
}
```

```
internal\version\zz_lintprobe_test.go:7:37: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
```

Probe deleted. The enabled set is the standard five (errcheck, govet, ineffassign, staticcheck, unused) plus errorlint — confirmed with `golangci-lint linters`, nothing dropped. `golangci-lint config verify` passes against the pinned schema, and the action's own `verify` input defaults to `true`, so CI catches schema drift too.

The action is pinned to a SHA; at that SHA `only-new-issues` defaults to `false`, `args` is empty and `working-directory` is unset, so every run lints the whole repo rather than just changed lines. `_test.go` files are linted too (v2 applies no default test exclusions), which is what makes the seven test suppressions necessary rather than decorative.

## Document the eight deliberate exceptions

Each now carries a `//nolint:errorlint` saying what the code wants, so the next reader sees the reason before deciding to "fix" it.

**Seven test assertions** compare with `!=` because they pin that `Cause` holds *one exact error*. `errors.Is` would also pass on any error in its chain — and in `cli_error_test.go` it would verify `Unwrap` by calling `Unwrap`, which is circular.

**`removeStaleUpdateFiles`** flattens the errno on purpose. Keeping it out of the chain is the entire point of `ErrLeftoverInUse`, and `assertBlockedLeftover` pins the contract.

The mechanism, for the record: with `%w` on the errno the format string has two `%w` verbs, so `fmt.Errorf` returns a `*fmt.wrapErrors` whose `Unwrap() []error` makes `errors.Is` traverse *both* branches. `unwrapPathError` strips the `*fs.PathError` down to a raw `syscall.Errno`, which implements `Is` mapping `EACCES` / `ERROR_ACCESS_DENIED` to `fs.ErrPermission`. `NotErrorIs` then fails — which is how the test caught this during #167.

## Corrections to this file

Two claims in `.golangci.yml` were wrong, both found in a second review pass over #166:

- It said this config **lifts the issue caps**. It doesn't. #156 added `max-issues-per-linter: 0` / `max-same-issues: 0` along with the file itself; #166 added the `formatters` block, dropped the then-redundant `linters: default: standard`, and rewrote both comments — but never touched the cap values. The comment now describes what the caps do without claiming credit for them.
- The `gofmt` formatter **simplifies by default**, so CI enforces `gofmt -s`, which is stricter than a plain gofmt-on-save. Confirmed against the pinned v2.12.2: `s[0:len(s)]` passes `gofmt -l` but fails `golangci-lint run`. That difference otherwise shows up as a CI failure a contributor cannot reproduce locally, so it is now stated in the file.

## CLAUDE.md

The linter stops a bad `%v` from landing, but it cannot stop the next `--fix` run from being trusted — and `errorlint` advertises itself as `[auto-fix]`, which invites exactly that. Trusting `--fix` is what produced all three defects reviewed in #167: a dropped condition in a type-assertion rewrite, seven tests loosened from "this exact error" to "somewhere in the chain", and a broken `%v` contract. The new section says review it hunk by hunk, and to check whether a newly wrapped error can be a `*CLIError` — that changes what `displayError` prints and whether usage help appears.

## What this does *not* cover

Worth stating so the linter isn't mistaken for total coverage:

- **`errorlint` only inspects `fmt.Errorf`.** A `%v` on an error inside `clierrors.Newf` / `Wrapf` / `NewUsageErrorf` passes CI silently — and those are the constructors `CLAUDE.md` tells you to reach for. No violations exist today, so this is a blind spot rather than a bug, and there is no golangci-lint setting that closes it. Now noted in `CLAUDE.md`.
- **`build.yaml` triggers on `push`, not `pull_request`.** A PR from a fork pushes to the fork, so the base repo never runs this job for it. Pre-existing, unrelated to this change, but it means "gates every PR" holds for same-repo branches only.

## Verification

- `make` — `0 issues`, build OK
- `go vet ./...` clean
- `go test ./...` — all packages pass
- Probe above confirms a new `%v` on an error now fails the build
- `nolintlint` reports no unused directives — verified meaningful by planting a gratuitous `//nolint` over a correct `%w` and watching it get flagged
- The `update.go` directive sits above a multi-line `fmt.Errorf` whose issue is reported on the *second* line; replicating that shape with extra violations after it confirms the directive covers the statement and nothing more — not the block, not the function
