### PR TITLE
Run CI on pull_request so fork PRs are gated

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,16 @@
 name: Build CLI
 
+# 'pull_request' also gates PRs from forks: a fork's push lands on the fork, so a
+# bare 'push' trigger never runs them here. 'push' is narrowed to the long-lived
+# branches so PR branches don't build twice; for a branch with no PR yet, use
+# workflow_dispatch.
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches:
+      - main
+      - dev
 
 run-name: Build from ${{ github.head_ref || github.ref_name }}
 


### PR DESCRIPTION
`build.yaml` triggered only on `push`. A PR from a fork pushes to the fork, so this workflow never ran for one in the base repo — an outside contribution could be reviewed and merged with no lint, no build, and no tests. Found while verifying that #168's `errorlint` guard really gates every PR; it does, for same-repo branches only.

```yaml
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches:
+      - main
+      - dev
```

## Why `pull_request` and not `pull_request_target`

`pull_request` checks out the merge commit and runs fork code with a **read-only** `GITHUB_TOKEN` and no access to secrets, regardless of the `permissions:` block. `pull_request_target` would run that same untrusted code with the base repo's write token — the standard way this gets exploited. Nothing in this workflow needs write access, so `pull_request` is both sufficient and the safe choice.

## Why `push` is narrowed

Left unscoped, a same-repo PR branch fires **both** events on every push and builds twice — two `ubicloud-standard-8` runs and two `windows-latest` runs per push, for identical commits. Narrowing `push` to the long-lived branches removes the duplicate while `pull_request` picks up topic branches.

`main` and `dev` match `publish-dev.yaml`'s own trigger, so a push that is about to be published is still built first. (`dev` does not exist today; including it keeps the two workflows consistent if it is created.)

**The trade:** pushing a topic branch no longer builds until a PR exists. `workflow_dispatch` covers the case where you want a run before opening one. The alternative — keeping `push` unscoped and deduplicating with a `concurrency` group — was rejected because the two events fire near-simultaneously, making which run survives racy and leaving cancelled checks that can block branch protection.

`run-name` already reads `github.head_ref || github.ref_name`, so it names the branch correctly under both events with no change.

## Verification

- YAML parses to the intended trigger set: `{workflow_dispatch, pull_request, push: {branches: [main, dev]}}`
- `actionlint` reports nothing on this change — its only finding is the pre-existing `ubicloud-standard-8` runner label, which it cannot resolve as a self-hosted label
- This PR is itself the test: it comes from a same-repo branch, so the checks below arrive via the new `pull_request` trigger rather than `push`
