### PR TITLE
List the binary file paths that cannot be preserved in the SDK patch

### DIFF
--- a/cmd/sdk_modification_check.go
+++ b/cmd/sdk_modification_check.go
@@ -636,15 +636,16 @@ func DetectSdkModificationsWithPatch(sdkRootDir string, sdkZipPath string) (*Sdk
 	}, nil
 }
 
-// countBinaryFiles returns the number of binary files in the modifications list.
-func countBinaryFiles(modifications []ModifiedFile) int {
-	count := 0
+// binaryModifiedFiles returns the binary files in the modifications list.
+// These cannot be included in the patch and must be restored manually.
+func binaryModifiedFiles(modifications []ModifiedFile) []ModifiedFile {
+	var binaries []ModifiedFile
 	for _, m := range modifications {
 		if m.IsBinary {
-			count++
+			binaries = append(binaries, m)
 		}
 	}
-	return count
+	return binaries
 }
 
 // printModifiedFilesList prints the list of modified files to the log.

--- a/cmd/update_sdk.go
+++ b/cmd/update_sdk.go
@@ -202,14 +202,10 @@ func (o *updateSdkOpts) Run(cmd *cobra.Command) error {
 		// Warn about binary files that cannot be included in the patch
 		binaryFiles := binaryModifiedFiles(modifications)
 		if len(binaryFiles) > 0 {
-			log.Info().Msg(styles.RenderWarning(fmt.Sprintf("WARNING: %d binary file(s) cannot be included in the patch and WILL BE LOST!", len(binaryFiles))))
-			log.Info().Msg("         You must manually back up and restore these files:")
-			const maxBinariesToShow = 10
-			for _, m := range binaryFiles[:min(len(binaryFiles), maxBinariesToShow)] {
+			log.Info().Msg(styles.RenderWarning(fmt.Sprintf("WARNING: The following binary files cannot be included in the patch any WILL BE OVERWRITTEN!", len(binaryFiles))))
+			log.Info().Msg("         We recommend backing up these files and restoring them after the update:")
+			for _, m := range binaryFiles {
 				log.Info().Msgf("           [%s] %s", m.ModType, m.RelativePath)
-			}
-			if len(binaryFiles) > maxBinariesToShow {
-				log.Info().Msgf("           ... and %d more binary file(s)", len(binaryFiles)-maxBinariesToShow)
 			}
 			log.Info().Msg("")
 		}

--- a/cmd/update_sdk.go
+++ b/cmd/update_sdk.go
@@ -202,8 +202,8 @@ func (o *updateSdkOpts) Run(cmd *cobra.Command) error {
 		// Warn about binary files that cannot be included in the patch
 		binaryFiles := binaryModifiedFiles(modifications)
 		if len(binaryFiles) > 0 {
-			log.Info().Msg(styles.RenderWarning(fmt.Sprintf("WARNING: The following binary files cannot be included in the patch any WILL BE OVERWRITTEN!", len(binaryFiles))))
-			log.Info().Msg("         We recommend backing up these files and restoring them after the update:")
+			log.Info().Msg(styles.RenderWarning("WARNING: The following binary files won't be included in the patch and WILL BE OVERWRITTEN!"))
+			log.Info().Msg("         Back up the files if you want to retain any potential modifications in them:")
 			for _, m := range binaryFiles {
 				log.Info().Msgf("           [%s] %s", m.ModType, m.RelativePath)
 			}

--- a/cmd/update_sdk.go
+++ b/cmd/update_sdk.go
@@ -202,8 +202,8 @@ func (o *updateSdkOpts) Run(cmd *cobra.Command) error {
 		// Warn about binary files that cannot be included in the patch
 		binaryFiles := binaryModifiedFiles(modifications)
 		if len(binaryFiles) > 0 {
-			log.Info().Msg(styles.RenderWarning("WARNING: The following binary files won't be included in the patch and WILL BE OVERWRITTEN!"))
-			log.Info().Msg("         Back up the files if you want to retain any potential modifications in them:")
+			log.Info().Msg(styles.RenderWarning("WARNING: Binary files cannot be included in the patch and WILL BE OVERWRITTEN!"))
+			log.Info().Msg("         Back up these files if you want to keep your changes:")
 			for _, m := range binaryFiles {
 				log.Info().Msgf("           [%s] %s", m.ModType, m.RelativePath)
 			}

--- a/cmd/update_sdk.go
+++ b/cmd/update_sdk.go
@@ -200,10 +200,17 @@ func (o *updateSdkOpts) Run(cmd *cobra.Command) error {
 		log.Info().Msg("")
 
 		// Warn about binary files that cannot be included in the patch
-		binaryCount := countBinaryFiles(modifications)
-		if binaryCount > 0 {
-			log.Info().Msg(styles.RenderWarning(fmt.Sprintf("WARNING: %d binary file(s) cannot be included in the patch and WILL BE LOST!", binaryCount)))
-			log.Info().Msg("         You must manually back up and restore these files.")
+		binaryFiles := binaryModifiedFiles(modifications)
+		if len(binaryFiles) > 0 {
+			log.Info().Msg(styles.RenderWarning(fmt.Sprintf("WARNING: %d binary file(s) cannot be included in the patch and WILL BE LOST!", len(binaryFiles))))
+			log.Info().Msg("         You must manually back up and restore these files:")
+			const maxBinariesToShow = 10
+			for _, m := range binaryFiles[:min(len(binaryFiles), maxBinariesToShow)] {
+				log.Info().Msgf("           [%s] %s", m.ModType, m.RelativePath)
+			}
+			if len(binaryFiles) > maxBinariesToShow {
+				log.Info().Msgf("           ... and %d more binary file(s)", len(binaryFiles)-maxBinariesToShow)
+			}
 			log.Info().Msg("")
 		}
 


### PR DESCRIPTION
## Problem

`metaplay update sdk` warns that binary files cannot be included in the patch, but it only reported a count. The paths were not reliably visible anywhere:

- The general modified-files list marks binaries with `(binary)`, but it is capped at 20 entries, so binaries beyond the cutoff are collapsed into `... and N more file(s)`.
- Deleted entries are appended from a map iteration, so their ordering is nondeterministic between runs.
- The generated patch file contains no trace of them: binaries are skipped silently during patch generation, with no `Binary files differ` marker.

So the files that need manual attention were exactly the ones the output could hide.

## Change

- Replace `countBinaryFiles` with `binaryModifiedFiles`, which returns the filtered slice instead of just a count. Callers use `len()` where they need the number.
- Print every binary file under the warning, each with its modification type. No cap: giving visibility into what the patch cannot preserve is the point.
- Phrase the backup step as a recommendation rather than an instruction. What to do about these files is the user's call.

The general list keeps its own cap of 20, so the binaries are always shown regardless of where they fall in that list.

Output now looks like:

```
WARNING: Binary files cannot be included in the patch and WILL BE OVERWRITTEN!
         Back up these files if you want to keep your changes:
           [modified] Assets/Plugins/foo.dll
           [added] Assets/Art/logo.png
           [deleted] Backend/lib/bar.so
```

## Verification

`go build ./...`, `go vet ./cmd/`, `go test ./cmd/` all pass. `gofmt -l ./cmd` clean, `go mod tidy` produces no changes.

## Follow-ups (not in this PR)

- The 20-entry cap on the general list is arbitrary (it arrived with the original command in #95 and was never revisited). Printing the full list with all actionable info below it is under discussion.
- `filepath.WalkDir` in `DetectSdkModificationsWithPatch` does not skip `.git`, so a nested checkout or submodule under `MetaplaySDK/` would report every object blob as an added binary file.
- When every modification is binary, `patchContent` is empty and no patch file is written, yet the output still prints the patch path and `patch -p1 < ...` re-apply instructions.